### PR TITLE
ci: route docs build to self-hosted Mac mini runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,12 @@ on:
     branches: [main]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Self-hosted Mac mini — this repo is private and the org's
+    # GitHub-hosted minute budget is exhausted (every ubuntu-latest job
+    # dies in 2s with no step output). Per the 2026-04-22 carve-out:
+    # private repos run on self-hosted; public repos use ubuntu-latest
+    # (still free).
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Why

Every \`ubuntu-latest\` run has been dying in ~2s with zero step output (runner allocated → killed before \`actions/checkout\` even runs). That's the signature of the org's GitHub-hosted Actions minute budget being exhausted — prior commit #84 even merged with "despite CI billing" in the message.

Local \`npm run build\` passes cleanly (Next 16.2.4 Turbopack, 105 static pages). So this is a runner-allocation issue, not a code issue.

## What

Flips \`runs-on\` from \`ubuntu-latest\` to \`self-hosted\`. Per the 2026-04-22 runner policy, private repos (like this one) run on the Mac mini self-hosted runner; public repos stay on \`ubuntu-latest\` (free regardless of minute budget).

## Test plan
- [x] Local \`npm run build\` passes
- [ ] CI re-runs on this PR and actually executes its steps (not silent 2s death)