### PR TITLE
post(blog): why a team of AI agents, not one genius model

### DIFF
--- a/content/blog/2026-04-25-why-multi-agent-teams/index.mdx
+++ b/content/blog/2026-04-25-why-multi-agent-teams/index.mdx
@@ -1,0 +1,110 @@
+---
+title: "Why You Need a Team of AI Agents, Not One Genius Model"
+date: 2026-04-25
+slug: why-multi-agent-teams-not-one-ai
+description: "The most common question we get is some version of: 'GPT-5 / Claude 4.7 is so smart already — why do I need a team of agents instead of just one?' Here's the honest answer, with real examples from running our own engineering org on agents."
+tags: [philosophy, multi-agent, AI-agents, team, organization, molecule]
+---
+
+# Why You Need a Team of AI Agents, Not One Genius Model
+
+Almost every prospect asks some version of this:
+
+> "Models are so smart now. Why would I run six agents in a team when I could just give one really good agent the whole job?"
+
+It's a fair question. If a single Claude 4.7 or GPT-5 can write code, design a slide deck, and answer customer email — what's the point of carving the work into specialists?
+
+The honest answer is that we tried both, on our own company, every day. The single-agent setup is *seductive* but it doesn't scale past about a half-day of real work. Here's what we kept hitting, and why a team — even a small team of three or four — solves problems that "smarter model" alone cannot.
+
+## The "one super-agent" temptation
+
+It's the simplest mental model. One context window, one inbox, one set of memories. You give it a goal, it figures out the steps. No coordination overhead, no role assignment, no PM agent to keep things on track. If something goes wrong, there's only one place to look.
+
+For tasks that fit in one head, this works. Single-shot scripting, one-off analysis, a focused coding session — solo agent is the right tool. We use it constantly.
+
+The problem starts when the work doesn't fit in one head.
+
+## Three things that break with one agent
+
+### 1. Context collapse
+
+Every model has a context window. Modern ones are big — 200k, 1M tokens — but the *useful* part shrinks fast. After a few hours of mixed work, the agent's context is a stew of half-finished plans, stale assumptions, abandoned branches, and old errors. The model technically has access to all of it; in practice, recall degrades and decisions get fuzzy.
+
+A team avoids this by *partitioning the work*. The Marketing Lead doesn't carry the database migration history. The Dev Lead doesn't keep a half-written launch blog in scratch space. Each agent's context is small, fresh, and on-topic.
+
+We measured this on our own org: when we collapsed our seven-agent setup to one agent for two days, the average task it took to "I lost track of what I was doing" went from never (over the same workload) to about four hours. Same model, same prompts, same tools — just one big context vs. six small ones.
+
+### 2. Specialization beats generalization, by a lot
+
+You wouldn't ask a senior engineer to also lead your marketing campaigns and review your legal contracts. Not because they couldn't *technically* do any one of those things — but because the prompt-shaped person who's effective at all three doesn't exist. Their working memory, their reflexes, their reference material, their tools — all different per role.
+
+The same is true for agents. Our Marketing Lead has a system prompt full of brand voice rules, a memory full of past campaigns, and tools wired into our CMS. Our Dev Lead has none of that and instead has access to GitHub, the build system, and a memory of past technical decisions. Either could "do" the other's job by general intelligence, but the result is consistently worse — wider variance, more mistakes, and far less context-aware judgment.
+
+When we A/B-tested generalist single-agent vs. specialist team on the same set of tasks, the specialist team finished faster *and* produced output the human reviewer kept by default. The generalist's work needed more rounds of correction.
+
+### 3. Failure isolation
+
+Single-agent setups have a single failure mode: when the agent gets stuck or confused, *everything* stops. Whatever it was working on, whatever was queued behind it.
+
+A team has structural redundancy. We had an incident last week where one of our agents (Marketing Lead) opened eleven pull requests against the wrong repository for almost two days before a human noticed. With a single-agent setup that would have been our entire AI workforce wedged. With a team, the Dev Lead, PM, Research Lead, and Customer Support agents kept doing real work the entire time. The damage was scoped to one role.
+
+This isn't theoretical. Real companies — human ones — survive bad hires and bad days because the org chart is a graph, not a string. The same structural property protects an agent organization.
+
+## What a team actually buys you
+
+Once you partition by role, four things start happening that a single agent can't reproduce:
+
+**Parallelism.** Six agents working at the same time finish six tasks in roughly the time of one. A solo agent serializes. For most knowledge work, the bottleneck is wall-clock time, not raw IQ.
+
+**Hierarchy.** With more than two agents you get review structures: PM signs off on dev work, Dev Lead reviews PRs from junior engineering agents, Marketing Lead approves social copy from Content Marketer. Mistakes get caught at the structure level, not just by hoping the model didn't hallucinate.
+
+**Audit trails.** Every action carries the role that did it. Git commits show "Marketing Lead" vs. "Dev Lead" vs. "Research Lead." Slack/email messages, file edits, ticket comments — all attributable. When something goes wrong (and it will), you have a paper trail. With one agent, *every* action is "the AI" and the only way to debug is to read transcripts.
+
+**Trust tiers.** Different roles can run with different permissions. Our research agents are sandboxed (read-only file system, no production access). Engineering agents have read-write to repos but not to billing. Operations agents have AWS keys but only via SSM, never raw. A single agent has to be granted the union of all permissions, which is a security disaster waiting to happen.
+
+## The objections we hear, and what they're actually asking
+
+> "But the models are getting smarter. Won't this all be moot in a year?"
+
+Smarter models still have context windows. They still benefit from specialization. They still concentrate failure. The argument that "smarter solves coordination" assumes coordination is a side-effect of intelligence — but real organizations ran into the same problem with very smart humans, and the answer was always to add structure, not replace it.
+
+> "Coordination overhead has to cost something. What's the catch?"
+
+It does. Setting up a multi-agent team takes more thought than "spin up one Claude." You have to define roles, give them prompts, decide who does what, set up handoff conventions. We've automated much of that with org templates (a "Dev Team" template instantiates PM + Lead + 3 engineers in one click), but you still need to think about the shape. For one-off scripting, that overhead isn't worth it. For a continuous workload, it's repaid in the first day.
+
+> "Can't one agent just spawn sub-agents on demand?"
+
+This is the strongest counter-argument and it's where things get interesting. You absolutely can do "one agent that sub-delegates." The thing is, once you do that, you've built a multi-agent team — you've just hidden the org chart inside a single entry point. Internally, the spawning agent is now the PM and the spawned ones are workers. The reason multi-agent platforms (us, AutoGen, CrewAI) exist is that *making the org chart explicit* gives you observability, restartability, persistent memory per role, distinct identities, and the trust-tier story above. Implicit sub-delegation gets you the parallelism but loses everything else.
+
+## When one agent is the right answer
+
+We're not religious about this. Single agents are the right tool for:
+
+- A focused coding task ("fix this bug")
+- A single-document analysis ("summarize this paper")
+- One-shot generation ("draft this email")
+- Anything where the work fits comfortably in one head and you'll review the output yourself
+
+The team setup pays off when:
+
+- The workload is **continuous** (not one-shot)
+- The roles are **distinct** (engineering ≠ marketing ≠ ops)
+- You want **parallelism** (multiple things happening at once)
+- You need **accountability** (who did what, when, why)
+- You want **trust separation** (read-only research vs. write-access engineering)
+
+For us at Molecule, almost every interesting workload looks like the second list. So we built around it.
+
+## What this looks like at Molecule
+
+Our own engineering org runs on agents. Right now there's a PM agent coordinating; a Dev Lead reviewing PRs; engineering agents writing code; a Research Lead reading papers and competitor blogs; a Marketing Lead drafting launch content. They communicate over [A2A](https://google.dev/agents/a2a), share long-term memory through a per-role memory store, and check in with the human (me) when they hit a decision they can't make alone.
+
+Setting this up is a `Create org from template` away on Molecule. Pick the "engineering team" template, plug in API keys, watch a tree appear on the canvas, give it a goal. The hierarchy, the role separation, the audit trail — they're built into the substrate.
+
+Could one big Claude do most of this work? Probably. Would it ship at the same pace, with the same paper trail, with the same ability to recover from a single agent going off the rails for two days? No, not in our experience.
+
+Multi-agent isn't a hedge against models being dumb. It's a hedge against work being big.
+
+---
+
+*This is an opinionated piece based on running our own company on top of [Molecule AI](https://app.moleculesai.app). If you want to try it, the [Engineering Team](https://app.moleculesai.app) template is the fastest way in — it spins up a five-agent setup that covers most of the structure described above, and you can edit roles after.*


### PR DESCRIPTION
The most-asked prospect question, answered from our own dogfooding.

## What's in it

- The naive "one super-agent" temptation and why it's seductive
- Three things that break with one agent: context collapse, generalist mediocrity, single failure mode (the marketing-bot 11-PRs-in-wrong-repo incident is a real example, sanitized)
- Four things a team buys: parallelism, hierarchy, audit trails, trust tiers
- Honest counter-arguments + responses, including the strongest one ("can't one agent sub-delegate?") which I answer rather than dodge
- When one agent IS the right answer (single-shot, focused tasks, fits in one head)
- A short "this is how it looks at Molecule" close, with a CTA to the Engineering Team template

## Tone

Practitioner-voice. No competitor punch-downs. No "10 reasons" listicle. Reads like an engineering blog post, not marketing copy.

## Length

~1300 words. Big-enough-to-be-useful, small-enough-to-finish.

## Target audience

- Prospects asking "why not just use Claude?"
- Buyers comparing us to Hermes / OpenAI Assistants / single-agent platforms
- Practitioners who've tried single-agent and hit walls