### PR TITLE
chore(ci): enroll in org-wide secret-scan reusable workflow (Molecule-AI/molecule-core#2109)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,22 @@
+name: Secret scan
+
+# Calls the canonical reusable workflow in molecule-core. Defense
+# against the #2090-class leak (a hosted-agent commit slipping a
+# credential-shaped string into a PR). Pattern set lives in
+# molecule-core so we don't maintain a parallel copy here.
+#
+# Pinned to @staging because that's the active default branch on the
+# upstream repo (main lags behind via the staging-promotion workflow).
+# Updates ride along automatically as the upstream regex set evolves.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, staging]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  secret-scan:
+    uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging

--- a/content/docs/incidents/INCIDENT_LOG.md
+++ b/content/docs/incidents/INCIDENT_LOG.md
@@ -88,7 +88,7 @@ Commit `d513a0ced549ef2be8903a7b4794256110ba1805` on staging (merged to main via
 |---|------------|-------|--------|
 | 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-lHt-QFSyZwZxeo...KVw` | ⚠️ Revoked or inactive (404 on API call) |
 | 2 | GITHUB_TOKEN | `github_pat_11BPRRWQI0m...hsIJLIL` | ✅ Revoked (confirmed 401) |
-| 3 | ADMIN_TOKEN | `HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=` | Needs confirmation — treated as active until proven otherwise |
+| 3 | ADMIN_TOKEN | `HlgeMb8...ShARE=` | Needs confirmation — treated as active until proven otherwise |
 
 ### Resolution
 
@@ -104,11 +104,13 @@ The commit itself fixed the problem by replacing hardcoded defaults with env-var
 
 ### Credentials Exposed
 
-| # | Credential | Value (redacted reference) | Service |
-|---|------------|------------------------------|---------|
-| 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-lHt-QFSyZwZxeo_fMbmLUX3VgHOwbKGMXUZb6PS2U15D3fqjDB2qPh1OVEzvfvWs9CgcrUpyU7C682uVT_8GBy9RFLaFzBcdLkKdVcPX4yj9UaXNTH82KVw` | MiniMax API (api.minimax.io/anthropic) |
-| 2 | GITHUB_TOKEN | `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` | GitHub (fine-grained PAT, scope unknown) |
-| 3 | ADMIN_TOKEN | `HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=` | Platform admin authentication |
+> **Token values redacted from this table 2026-04-26** to reduce public-search surface (the docs repo is publicly indexed). Short-suffix references match the convention in the Blast Radius table below (lines 134-137). Full values remain in `molecule-core` git history per the F1088 closure decision (no BFG scrub).
+
+| # | Credential | Value (short suffix) | Service |
+|---|------------|----------------------|---------|
+| 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-...KVw` | MiniMax API (api.minimax.io/anthropic) |
+| 2 | GITHUB_TOKEN | `github_pat_...hsIJLIL` | GitHub (fine-grained PAT, scope unknown) |
+| 3 | ADMIN_TOKEN | `HlgeMb8...ShARE=` | Platform admin authentication |
 
 ### Affected Files
 
@@ -153,10 +155,13 @@ The commit itself fixed the problem by replacing hardcoded defaults with env-var
 
 **Step 1 — Create credentials manifest (`creds.txt`) [NOT NEEDED]:**
 ```
-HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=
-sk-cp-lHt-QFSyZwZxeo_fMbmLUX3VgHOwbKGMXUZb6PS2U15D3fqjDB2qPh1OVEzvfvWs9CgcrUpyU7C682uVT_8GBy9RFLaFzBcdLkKdVcPX4yj9UaXNTH82KVw
-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
+<ADMIN_TOKEN value>
+<MiniMax sk-cp-... value>
+<GitHub fine-grained PAT value>
 ```
+Full token values redacted from this doc 2026-04-26 (see note in the
+Credentials Exposed table above). Pull from the Core-Security incident
+ticket if a future revival of this BFG procedure is needed.
 
 **Step 2 — Clean origin/main:**
 ```bash


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

3-line enrollment in the canonical secret-scan workflow shipped in Molecule-AI/molecule-core#2109. Defense against the #2090-class leak (a hosted-agent commit slipping a credential-shaped string into a PR — caught at the PR layer, before merge).

High priority for this repo: per the org audit-log review, `docs` was the #2 most-touched repo by the hosted Copilot Coding Agent (170 events / 7d, behind only molecule-core's 1,781). Public-facing docs are also the surface most likely to embed example tokens / API keys that LOOK fake but match real patterns.

Pattern set lives in molecule-core; updates ride along automatically.