### PR TITLE
security(incident-log): redact full token values from F1088 incident report

### DIFF
--- a/content/docs/incidents/INCIDENT_LOG.md
+++ b/content/docs/incidents/INCIDENT_LOG.md
@@ -88,7 +88,7 @@ Commit `d513a0ced549ef2be8903a7b4794256110ba1805` on staging (merged to main via
 |---|------------|-------|--------|
 | 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-lHt-QFSyZwZxeo...KVw` | ⚠️ Revoked or inactive (404 on API call) |
 | 2 | GITHUB_TOKEN | `github_pat_11BPRRWQI0m...hsIJLIL` | ✅ Revoked (confirmed 401) |
-| 3 | ADMIN_TOKEN | `HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=` | Needs confirmation — treated as active until proven otherwise |
+| 3 | ADMIN_TOKEN | `HlgeMb8...ShARE=` | Needs confirmation — treated as active until proven otherwise |
 
 ### Resolution
 
@@ -104,11 +104,13 @@ The commit itself fixed the problem by replacing hardcoded defaults with env-var
 
 ### Credentials Exposed
 
-| # | Credential | Value (redacted reference) | Service |
-|---|------------|------------------------------|---------|
-| 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-lHt-QFSyZwZxeo_fMbmLUX3VgHOwbKGMXUZb6PS2U15D3fqjDB2qPh1OVEzvfvWs9CgcrUpyU7C682uVT_8GBy9RFLaFzBcdLkKdVcPX4yj9UaXNTH82KVw` | MiniMax API (api.minimax.io/anthropic) |
-| 2 | GITHUB_TOKEN | `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` | GitHub (fine-grained PAT, scope unknown) |
-| 3 | ADMIN_TOKEN | `HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=` | Platform admin authentication |
+> **Token values redacted from this table 2026-04-26** to reduce public-search surface (the docs repo is publicly indexed). Short-suffix references match the convention in the Blast Radius table below (lines 134-137). Full values remain in `molecule-core` git history per the F1088 closure decision (no BFG scrub).
+
+| # | Credential | Value (short suffix) | Service |
+|---|------------|----------------------|---------|
+| 1 | ANTHROPIC_AUTH_TOKEN | `sk-cp-...KVw` | MiniMax API (api.minimax.io/anthropic) |
+| 2 | GITHUB_TOKEN | `github_pat_...hsIJLIL` | GitHub (fine-grained PAT, scope unknown) |
+| 3 | ADMIN_TOKEN | `HlgeMb8...ShARE=` | Platform admin authentication |
 
 ### Affected Files
 
@@ -153,10 +155,13 @@ The commit itself fixed the problem by replacing hardcoded defaults with env-var
 
 **Step 1 — Create credentials manifest (`creds.txt`) [NOT NEEDED]:**
 ```
-HlgeMb8LjQLXg/B4y8hYzhbCQlg5LNu0oEa4IjShARE=
-sk-cp-lHt-QFSyZwZxeo_fMbmLUX3VgHOwbKGMXUZb6PS2U15D3fqjDB2qPh1OVEzvfvWs9CgcrUpyU7C682uVT_8GBy9RFLaFzBcdLkKdVcPX4yj9UaXNTH82KVw
-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
+<ADMIN_TOKEN value>
+<MiniMax sk-cp-... value>
+<GitHub fine-grained PAT value>
 ```
+Full token values redacted from this doc 2026-04-26 (see note in the
+Credentials Exposed table above). Pull from the Core-Security incident
+ticket if a future revival of this BFG procedure is needed.
 
 **Step 2 — Clean origin/main:**
 ```bash


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

## Background

Molecule-AI/molecule-core#2109 shipped an org-wide secret-scan workflow. The first repo it caught a real match in was THIS one — `content/docs/incidents/INCIDENT_LOG.md`.

The F1088 incident report documented three production credentials that leaked via molecule-core PR #1098 (commit d513a0c), and then **INCLUDED THEM IN PLAINTEXT IN THE DOCUMENTATION ITSELF**. The incident report became a secondary leak surface — and the docs repo is publicly indexed.

## Token status (per the report's own Blast Radius table)

| Credential | Status |
|------------|--------|
| MiniMax `sk-cp-...KVw` | Revoked / endpoint inactive (404) |
| GitHub PAT `github_pat_...hsIJLIL` | Revoked (confirmed 401) |
| Admin token `HlgeMb8...ShARE=` | Treated as active, rotation pending |

Two of three are confirmed revoked. The third (admin token) is still pending rotation per the report itself.

## What this PR does

- Replaces the full values in the Credentials Exposed table with the short-suffix convention already used in the Blast Radius table (lines 134-137 before this change). Audit trail preserved.
- Replaces the BFG creds.txt example block with placeholders + a note pointing operators to the internal incident ticket if the procedure is ever revived.
- Adds an explicit redaction note explaining what changed and why.

## What this PR does NOT change

- Full values still exist in `molecule-core` git history per F1088's explicit closure decision (no BFG scrub required, no active public forks).
- This PR is additive defense — removes one more visible copy. Doesn't change the incident closure status.

## Asks for the user (separate from this PR)

1. **Confirm admin token rotation status.** F1088 marked it 'treated as active until proven otherwise' on the original incident date. If it's still un-rotated, that's a separate item to handle.
2. **Decide whether to rotate** even the confirmed-revoked tokens as defense-in-depth. Probably not — but worth a moment's thought now that the secret-scan rollout has surfaced the public-visibility angle.

## Test plan

- [x] Local `git grep` confirms no full token values remain in the working tree
- [ ] CI green — the secret-scan workflow on this PR should now PASS (the only added lines are the redaction note + short-suffix references that don't match the patterns)
- [ ] Post-merge: re-run org-wide secret scan on a fresh PR opened against this repo to confirm zero matches