### PR TITLE
docs(workspace-runtime): clarify what the boot-smoke gate does NOT prove

### DIFF
--- a/content/docs/agent-runtime/workspace-runtime.md
+++ b/content/docs/agent-runtime/workspace-runtime.md
@@ -113,6 +113,14 @@ fi
 - `adapter.create_executor()` runs
 - `executor.execute()` is invoked once against a stub `RequestContext`/`EventQueue` with `MOLECULE_SMOKE_TIMEOUT_SECS` (default 5s); a clean timeout exits 0, an import error exits non-zero
 
+### What the gate does NOT prove
+
+A green gate means **"imports are healthy enough that `executor.execute()` reaches its body"** — that's the regression class the gate exists to catch (lazy `from x import y` inside an `if`-branch, or `importlib.import_module()` on a path that breaks after a wheel bump).
+
+It does **not** prove that `execute()` produces the right output for real input. Adapters that make real I/O calls inside `execute()` (subprocess to a gateway, httpx call to an upstream LLM) will time out under the harness's default 5s window, and the gate treats a clean timeout as success. The stub `RequestContext` carries an empty user message and the harness never inspects what `execute()` writes back.
+
+If you need correctness coverage, write a separate integration test that runs the workspace against real or mocked infrastructure — the smoke gate is a strict subset.
+
 ### Stub env the smoke harness sets
 
 | Var | Value |


### PR DESCRIPTION
## Summary

The smoke-contract section added in [#106](https://github.com/Molecule-AI/docs/pull/106) explains what the gate **does** exercise, but doesn't say what it **doesn't**. Adapters that do real I/O inside \`execute()\` (subprocess spawn, httpx call) time out under the harness's 5s window, and the gate treats that timeout as success — so a green gate is an import-regression signal, not a runtime-correctness signal.

## Why this matters

Surfaced while running publish-image across all 8 workspace templates: openclaw's smoke run "passed" specifically because \`OpenClawA2AExecutor.execute()\` proxies to an absent gateway subprocess and timed out cleanly. Future operators reading the green check might over-trust it. The new subsection makes the boundary explicit:

- gate covers: lazy imports inside \`execute()\`'s body
- gate does NOT cover: whether \`execute()\` produces the right output, network behavior, gateway integration, etc.

## Test plan
- [ ] Renders cleanly in the fumadocs preview
- [ ] No conflicting language with the rest of the smoke-contract section

🤖 Generated with [Claude Code](https://claude.com/claude-code)