### PR TITLE
docs(workspace-runtime): correct smoke-gate caveat factual errors

### DIFF
--- a/content/docs/agent-runtime/workspace-runtime.md
+++ b/content/docs/agent-runtime/workspace-runtime.md
@@ -117,7 +117,13 @@ fi
 
 A green gate means **"imports are healthy enough that `executor.execute()` reaches its body"** — that's the regression class the gate exists to catch (lazy `from x import y` inside an `if`-branch, or `importlib.import_module()` on a path that breaks after a wheel bump).
 
-It does **not** prove that `execute()` produces the right output for real input. Adapters that make real I/O calls inside `execute()` (subprocess to a gateway, httpx call to an upstream LLM) will time out under the harness's default 5s window, and the gate treats a clean timeout as success. The stub `RequestContext` carries an empty user message and the harness never inspects what `execute()` writes back.
+It does **not** prove that `execute()` produces the right output for real input. The harness reports PASS in three distinct cases:
+
+1. **Clean return** — execute() ran to completion within the timeout.
+2. **Timeout** — execute() was still running when the timer fired (typical for adapters that do real I/O inside execute(): subprocess to a gateway, httpx call to an upstream LLM).
+3. **Any non-import exception** — execute() raised `RuntimeError`, auth errors, validation errors, etc. The harness only fails on `ImportError`/`ModuleNotFoundError`.
+
+The stub `RequestContext` carries a non-empty `"smoke test"` text message (so adapters relying on `extract_message_text(ctx)` returning input still work), and the harness never drains the `EventQueue` — what `execute()` writes back is ignored.
 
 If you need correctness coverage, write a separate integration test that runs the workspace against real or mocked infrastructure — the smoke gate is a strict subset.
 


### PR DESCRIPTION
## Summary

Two factual errors in the caveat I shipped in [#107](https://github.com/Molecule-AI/docs/pull/107):

1. **Stub message content** — claimed the stub \`RequestContext\` "carries an empty user message". It actually carries \`\"smoke test\"\` text. \`smoke_mode.py:76\` calls \`new_text_message(\"smoke test\")\` with the inline comment \"enough that \`extract_message_text(context)\` returns non-empty input\". An adapter author gating smoke-mode behavior on \`extract_message_text(ctx) == \"\"\` would have logic that never fires.

2. **Pass paths** — described only the timeout-pass case. The harness also returns 0 on **any non-import exception** (\`smoke_mode.py:135-143\`): the bare \`except Exception\` block treats \`RuntimeError\`, auth errors, validation errors etc. as \"downstream of the import gate\" and exits clean. Spelling out all three pass cases (clean return, timeout, non-import exception) is the honest description.

## Verification

Read \`workspace/smoke_mode.py:59-145\` (workspace runtime) line-by-line for this PR rather than recalling from memory. Each statement in the new text now corresponds to a specific code site:

| Doc claim | Code site |
|---|---|
| Clean return = pass | smoke_mode.py:144 (else branch of try/except) |
| Timeout = pass | smoke_mode.py:122-126 |
| Non-import exception = pass | smoke_mode.py:135-143 |
| ImportError = fail | smoke_mode.py:127-134 |
| Stub carries \"smoke test\" | smoke_mode.py:76 |
| EventQueue never drained | smoke_mode.py:80 (created, never read) |

## How this happened

I asserted both errors from memory while writing #107 instead of re-reading the source — exactly the failure mode the [\`feedback_always_run_e2e.md\` worked-example update](https://github.com/Molecule-AI/docs/pull/106) was warning future-me about. Caught during a review pass that explicitly went back to verify each claim.

## Test plan
- [ ] Renders cleanly in fumadocs preview
- [ ] No remaining inaccurate claims about gate behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)