### PR TITLE
docs(arch): correct staging DNS — per-tenant CNAME, no wildcard

### DIFF
--- a/content/docs/architecture/staging-environment.md
+++ b/content/docs/architecture/staging-environment.md
@@ -27,7 +27,8 @@ CP (Railway):       staging service                 production service
                     staging.api.moleculesai.app     api.moleculesai.app
 
 Tenant EC2s:        staging EC2 instances            production EC2 instances
-                    *.staging.moleculesai.app        *.moleculesai.app
+                    <slug>.staging.moleculesai.app   <slug>.moleculesai.app
+                    (per-tenant CNAME, no wildcard)  (per-tenant CNAME, no wildcard)
 
 App (Vercel):       staging.app.moleculesai.app     app.moleculesai.app
                     (Vercel preview)                 (Vercel production)
@@ -38,8 +39,10 @@ DB (Neon):          staging branch                   main branch
 Docker images:      platform-tenant:staging          platform-tenant:latest
                     (GHCR)                           (GHCR)
 
-Cloudflare:         *.staging.moleculesai.app        *.moleculesai.app
-                    (separate tunnel/worker)         (tunnel per tenant)
+Cloudflare:         per-tenant CNAMEs under          per-tenant CNAMEs under
+                    staging.moleculesai.app          moleculesai.app
+                    (one CNAME + one tunnel          (one CNAME + one tunnel
+                     per provisioned tenant)          per provisioned tenant)
 ```
 
 ## Deploy flow
@@ -115,15 +118,35 @@ platform-tenant:sha-xxxxx  — immutable, pinned to specific commit
 #       pushes :latest only on manual promote
 ```
 
-### 5. Cloudflare: staging subdomain
+### 5. Cloudflare: per-tenant CNAMEs (no wildcard)
 
-Option A (simple): `*.staging.moleculesai.app` with its own tunnel/worker
-Option B (full): separate Cloudflare zone for staging (overkill)
+There is **no `*.staging.moleculesai.app` wildcard record** and there is no
+`*.moleculesai.app` wildcard either. The control plane writes a per-tenant
+CNAME at provision time, pointing `<slug>.<env-domain>` at that tenant's
+Cloudflare tunnel (`<tunnel-id>.cfargotunnel.com`).
 
-Recommend Option A:
-- Add `staging.moleculesai.app` DNS records
-- Staging tenants get `slug.staging.moleculesai.app` subdomains
-- Production tenants get `slug.moleculesai.app` (unchanged)
+Verified in `molecule-controlplane/internal/provisioner/ec2.go` — the
+provisioner calls `Tunnel.CreateTunnelDNS(ctx, slug, domain, tunnelID)`
+during workspace provision, then records a `cf_dns` row in
+`tenant_resources` with `type=CNAME` for symmetric create/delete audit.
+
+Implications for staging:
+
+- Staging tenants get `<slug>.staging.moleculesai.app` only **after** they
+  are provisioned through the staging control plane. The CNAME is
+  written as part of `Provision()`.
+- Production tenants get `<slug>.moleculesai.app` the same way, against
+  the production CP.
+- Pre-provision, an unknown slug returns **NXDOMAIN**. This is correct
+  behavior, not a regression — there is no wildcard to catch the lookup.
+- Tests that hit a staging slug they have not provisioned themselves
+  will fail with `getaddrinfo ENOTFOUND` (Node) or `Name or service not
+  known` (curl). The fix is to provision your own slug against the
+  staging CP first; do not file this as an infrastructure bug.
+
+The same model applies to both environments — the only difference is
+the parent zone (`staging.moleculesai.app` vs `moleculesai.app`) and the
+CP that writes the records.
 
 ### 6. EC2: staging tag
 


### PR DESCRIPTION
## Summary

The \`staging-environment.md\` doc described tenant DNS as
\`*.staging.moleculesai.app\` and \`*.moleculesai.app\` wildcards. Those
wildcards do not exist. The control plane writes a per-tenant CNAME at
provision time — verified in
\`molecule-controlplane/internal/provisioner/ec2.go\` (calls
\`Tunnel.CreateTunnelDNS(ctx, slug, domain, tunnelID)\` and audits the
result as a \`cf_dns\` row with \`type=CNAME\`).

This PR rewrites the two DNS spots in the doc:

1. The "Architecture" ASCII diagram — replaces \`*.staging.moleculesai.app\`
   / \`*.moleculesai.app\` rows with \`<slug>.<env-domain>\` and a "no
   wildcard" annotation.
2. Section 5 — renamed to "Cloudflare: per-tenant CNAMEs (no wildcard)",
   spells out that NXDOMAIN on unknown slugs is **correct, not a
   regression**, and that test failures with \`getaddrinfo ENOTFOUND\` mean
   the slug is unprovisioned (operator must provision their own first).

## Why this matters

The old doc enabled a recurring misdiagnosis: tests against staging slugs
that were never provisioned would fail at DNS resolution, and operators
(and agents reading the doc) would file the failures as Cloudflare /
edge / staging-zone bugs. With the wildcard wording removed, the
expected behavior — NXDOMAIN until the slug is provisioned — is the
documented behavior.

## Scope

- One file changed: \`content/docs/architecture/staging-environment.md\`.
- Only the DNS sections were rewritten; the rest of the doc is
  untouched.
- No new "how to provision a tenant" runbook — that belongs in a
  separate doc.

## Test plan

- [ ] Render the page on staging-docs and skim for broken markdown
- [ ] Confirm the ASCII diagram still aligns with mono spacing