### PR TITLE
docs: update clone URLs after molecule-core repo split

### DIFF
--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -11,8 +11,8 @@ Get a Molecule AI workspace running in under five minutes.
 ## 1. Install Molecule AI
 
 ```bash
-git clone https://github.com/Molecule-AI/molecule-core.git
-cd molecule-core
+git clone https://github.com/Molecule-AI/molecule-monorepo.git
+cd molecule-monorepo
 docker compose up -d
 ```
 
@@ -78,4 +78,4 @@ Or type `/ask what's our deployment status?` in your connected Discord channel.
 - [Review the REST API reference](/docs/guides/org-api-keys)
 - [Browse all guides](/docs/guides)
 
-Explore the [GitHub repo](https://github.com/Molecule-AI/molecule-core) for self-hosting options, or visit [moleculesai.app](https://moleculesai.app) for the hosted platform.
+Explore the [GitHub repo](https://github.com/Molecule-AI/molecule-monorepo) for self-hosting options, or visit [moleculesai.app](https://moleculesai.app) for the hosted platform.

--- a/content/docs/self-hosting.mdx
+++ b/content/docs/self-hosting.mdx
@@ -17,8 +17,8 @@ description: Run the full Molecule AI stack on your own infrastructure.
 The fastest way to get Molecule AI running locally:
 
 ```bash
-git clone https://github.com/Molecule-AI/molecule-core.git
-cd molecule-core
+git clone https://github.com/Molecule-AI/molecule-monorepo.git
+cd molecule-monorepo
 ./scripts/dev-start.sh
 # Canvas: http://localhost:3000
 # Platform: http://localhost:8080


### PR DESCRIPTION
## Summary
- `molecule-core` was split: Canvas + platform live in `molecule-monorepo`, control-plane lives in `molecule-controlplane`.
- Both clone references in quickstart + self-hosting point at the Canvas/platform stack (`./scripts/dev-start.sh`, `canvas/`, `platform/`, `docker-compose.infra.yml`), so they map to `molecule-monorepo`.
- Three references updated total — two in `content/docs/quickstart.md` (clone block + footer GitHub link), one clone block in `content/docs/self-hosting.mdx`.

## Test plan
- [ ] CI doc build passes
- [ ] Visual check: clone commands resolve to a real repo