### PR TITLE
docs: align runtime lists with workspace-server allowlist; drop stale NemoClaw/NVIDIA claims

### DIFF
--- a/content/docs/agent-runtime/workspace-runtime.md
+++ b/content/docs/agent-runtime/workspace-runtime.md
@@ -9,16 +9,18 @@ The `workspace/` directory is Molecule AI's unified runtime image. Every provisi
 
 ## Runtime Matrix In Current `main`
 
-Current `main` ships six adapters:
+Current `main` ships eight adapters:
 
-- `langgraph`
-- `deepagents`
 - `claude-code`
+- `langgraph`
 - `crewai`
 - `autogen`
+- `deepagents`
+- `hermes`
+- `gemini-cli`
 - `openclaw`
 
-This is the merged runtime surface today. Branch-level experiments such as NemoClaw are separate and should be treated as roadmap/WIP, not merged support.
+This is the merged runtime surface today. The canonical allowlist lives in `workspace-server/internal/handlers/admin_workspace_images.go` (`AllRuntimes`). Anything not on this list — including BYO runtimes — registers via the [external workspace](../external-agents.mdx) path, not as a built-in adapter.
 
 Adapter-specific behavior is documented in [Agent Runtime Adapters](./cli-runtime.md).
 

--- a/content/docs/architecture/molecule-technical-doc.md
+++ b/content/docs/architecture/molecule-technical-doc.md
@@ -573,14 +573,16 @@ compliance:
 
 | Adapter | Core Strength | Image Tag |
 |---------|--------------|-----------|
-| **LangGraph** | Graph-based state machine, tool use, streaming | `workspace-template:langgraph` |
-| **DeepAgents** | Deep planning, multi-step task decomposition | `workspace-template:deepagents` |
 | **Claude Code** | Native coding workflows, CLI continuity, OAuth auth | `workspace-template:claude-code` |
+| **LangGraph** | Graph-based state machine, tool use, streaming | `workspace-template:langgraph` |
 | **CrewAI** | Role-based crews, structured task orchestration | `workspace-template:crewai` |
 | **AutoGen** | Multi-agent conversations, explicit strategies | `workspace-template:autogen` |
+| **DeepAgents** | Deep planning, multi-step task decomposition | `workspace-template:deepagents` |
+| **Hermes** | Multi-provider dispatch (Anthropic/Gemini native + OpenAI-compatible shim) | `workspace-template:hermes` |
+| **Gemini CLI** | Google Gemini CLI workspace | `workspace-template:gemini-cli` |
 | **OpenClaw** | CLI-native runtime, own session model | `workspace-template:openclaw` |
 
-**Branch-level WIP**: NemoClaw (NVIDIA T4 + Docker socket) on `feat/nemoclaw-t4-docker`.
+The canonical allowlist lives in `workspace-server/internal/handlers/admin_workspace_images.go` (`AllRuntimes`). Anything outside this list registers via the external-workspace path.
 
 Each adapter implements `setup()` + `create_executor()`. The base adapter provides shared infrastructure: system prompt assembly, skill loading, tool registration, coordinator detection, plugin injection.
 
@@ -978,7 +980,6 @@ Tools call `resp.json()` without catching JSON decode errors. Should wrap in try
 
 | Branch | Feature | Status |
 |--------|---------|--------|
-| `feat/nemoclaw-t4-docker` | NemoClaw adapter (NVIDIA T4 support) | WIP |
 | Backlog | Firecracker backend (faster cold starts) | Planned |
 | Backlog | E2B backend (cloud-hosted code sandbox) | Planned |
 | Backlog | pgvector semantic memory search | Planned |

--- a/content/docs/architecture/overview.md
+++ b/content/docs/architecture/overview.md
@@ -20,7 +20,7 @@ Canvas (Next.js :3000) ←WebSocket→ Platform (Go :8080) ←HTTP→ Postgres +
 
 - **Workspace Server** (`workspace-server/`): Go/Gin control plane — workspace CRUD, registry, discovery, WebSocket hub, liveness monitoring.
 - **Canvas** (`canvas/`): Next.js 15 + React Flow (@xyflow/react v12) + Zustand + Tailwind — visual workspace graph.
-- **Workspace Runtime** (`workspace/`): Shared runtime published as [`molecule-ai-workspace-runtime`](https://pypi.org/project/molecule-ai-workspace-runtime/) on PyPI. Supports LangGraph, Claude Code, OpenClaw, DeepAgents, CrewAI, AutoGen. Each adapter lives in its own standalone template repo (e.g. `molecule-ai-workspace-template-claude-code`). See `docs/workspace-runtime-package.md` for the full picture.
+- **Workspace Runtime** (`workspace/`): Shared runtime published as [`molecule-ai-workspace-runtime`](https://pypi.org/project/molecule-ai-workspace-runtime/) on PyPI. Supports Claude Code, LangGraph, CrewAI, AutoGen, DeepAgents, Hermes, Gemini CLI, and OpenClaw. Each adapter lives in its own standalone template repo (e.g. `molecule-ai-workspace-template-claude-code`). See `docs/workspace-runtime-package.md` for the full picture.
 - **molecli** (`workspace-server/cmd/cli/`): Go TUI dashboard (Bubbletea + Lipgloss) — real-time workspace monitoring, event log, health overview, delete/filter operations.
 
 ## Key Architectural Patterns

--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -26,7 +26,7 @@ lands in the watch list with a colliding term, add a row here.
 | **team** | A named cluster of workspaces under a PM (org template `expand_team`). Used for role grouping in Canvas. | **CrewAI**: a "crew" is a sequence of agents that pass a task through a declared order. Our "team" is an org-chart abstraction, not an execution order. |
 | **skill** | A directory with `SKILL.md` that an agent invokes via the `Skill` tool. Skills are documentation + optional scripts that teach an agent a recipe. | **Anthropic Skills API**: nearly identical. **CrewAI tool**: closer to our plugin's MCP tool, not our skill. |
 | **channel** | An outbound/inbound social integration (Telegram, Slack, …) per-workspace, wired in `workspace_channels`. | Slack's "channel": the container for messages. We use "channel" for the adapter + credentials, not the conversation itself. |
-| **runtime** | The execution engine image tag for a workspace: one of `langgraph`, `claude-code`, `openclaw`, `crewai`, `autogen`, `deepagents`, `hermes`. | **LangGraph runtime**: the Python process running the graph. We use "runtime" for the Docker image + adapter pairing, not the inner process. |
+| **runtime** | The execution engine image tag for a workspace: one of `claude-code`, `langgraph`, `crewai`, `autogen`, `deepagents`, `hermes`, `gemini-cli`, `openclaw`. | **LangGraph runtime**: the Python process running the graph. We use "runtime" for the Docker image + adapter pairing, not the inner process. |
 
 ## GitHub Awesome Copilot disambiguation
 


### PR DESCRIPTION
## Summary

Cross-checked every runtime list in molecule-docs against the canonical `AllRuntimes` allowlist in `workspace-server/internal/handlers/admin_workspace_images.go` (claude-code, langgraph, crewai, autogen, deepagents, hermes, gemini-cli, openclaw). Several lists were drifting toward an old 6-runtime snapshot missing **hermes** + **gemini-cli**, and two locations carried a stale **NemoClaw / NVIDIA T4** claim with no source presence anywhere in the monorepo (no `feat/nemoclaw-t4-docker` branch exists, no `nemoclaw` references outside docs).

## Files changed (4)

- `content/docs/agent-runtime/workspace-runtime.md` — runtime matrix corrected from 6 to 8; NemoClaw experimental-branch line deleted.
- `content/docs/architecture/molecule-technical-doc.md` — runtime table extended to 8; "Branch-level WIP: NemoClaw" line + branch-level table row deleted.
- `content/docs/architecture/overview.md` — `Supports …` runtime list extended to all 8.
- `content/docs/glossary.md` — runtime definition extended from 7 to 8 (added gemini-cli).

## False claims removed (with evidence)

- **NemoClaw / NVIDIA T4 adapter** — claimed twice in `molecule-technical-doc.md`, once in `workspace-runtime.md`. Verified `git branch -a` in `molecule-monorepo` returns nothing for `nemoclaw|openclaw` matching `feat/nemoclaw-*`; only `openclaw` is in `AllRuntimes`. NemoClaw is not real.

## Claims added (with evidence)

- **Hermes** + **Gemini CLI** added to runtime lists in `workspace-runtime.md`, `overview.md`, `glossary.md`, and `molecule-technical-doc.md`. Both are first-class entries in `AllRuntimes` (`admin_workspace_images.go:46-49`) and have dedicated template repos (`molecule-ai-workspace-template-hermes`, `molecule-ai-workspace-template-gemini-cli`).

## Out-of-scope sweep (no changes needed)

- **NeMo Guardrails** — zero references in molecule-docs (the word "guardrails" elsewhere refers to generic plugin/role guardrails, not NVIDIA's product).
- **Nemotron** — only appears in `molecule-monorepo` as a NIM-alias test fixture; no first-class model claim in docs to remove.
- Model lists already match `workspace/agent.py` (Anthropic Claude, OpenAI, Gemini, MiniMax, DeepSeek, Moonshot, Ollama, vLLM).
- Observability sinks (OpenTelemetry, Langfuse, Sentry, Prometheus) align with implementation.
- `index.mdx`, `concepts.mdx`, `architecture.mdx` already carry the full 8-runtime list.

## Test plan

- [x] `npm run build` — all 111 static pages regenerate cleanly
- [x] `grep -riE "nemoclaw|nemotron|nemo guardrails|nvidia"` returns 0 hits in `content/`
- [x] All 8 `AllRuntimes` entries present in every runtime list

🤖 Generated with [Claude Code](https://claude.com/claude-code)