### PR TITLE
docs: multi-workspace mode for the universal MCP server

### DIFF
--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -7,6 +7,22 @@ All notable changes to the Molecule AI platform are documented here.
 Entries are published daily at 23:50 UTC.
 
 ---
+## 2026-05-04
+
+### ✨ New features
+
+- **Multi-workspace mode for the universal MCP server**: a single `molecule-mcp` process can now register into N workspaces at once via the new `MOLECULE_WORKSPACES` JSON env var. Use case: an agent on a developer's PC that needs to participate in BOTH the company tenant's workspace AND a personal workspace — the same physical agent is reachable from either canvas, and `list_peers` aggregates peers across all registered workspaces with a `via: <src>` tag so the agent can tell which side surfaced each peer. Tools auto-route via a peer→source cache populated by `list_peers`, so agents rarely need to set the new `source_workspace_id` argument explicitly. Single-workspace operators see no behavior change. ([`molecule-core` #2739](https://github.com/Molecule-AI/molecule-core/pull/2739), [#2743](https://github.com/Molecule-AI/molecule-core/pull/2743))
+
+### 🔧 Fixes
+
+- **Tenant boot tail latency on apt-mirror slow days**: tenant boot's `install_apt_base` step previously varied 51s → 625s depending on apt-mirror weather, occasionally blowing the canary's 12-min job timeout. Fixed by baking `caddy` and `amazon-ssm-agent` into the thin tenant AMI alongside the workspace runtime images, turning the tenant user-data's two slowest install steps into 5s cache-hit no-ops. ([`molecule-controlplane` #462](https://github.com/Molecule-AI/molecule-controlplane/pull/462), Issue #456)
+- **Bake → deploy gap closed**: every successful `bake-thin-ami` workflow run now auto-promotes the new AMI ID into Railway staging's `EC2_AMI` variable, so the next tenant launch picks it up without a manual operator step. The promote step is gated on `auto_promote=true` (default) and reads the prior value first so the workflow log preserves a rollback target. ([`molecule-controlplane` #461](https://github.com/Molecule-AI/molecule-controlplane/pull/461) — RFC #388 PR-6)
+
+### 📚 Docs
+
+- **Multi-workspace MCP guide**: new section in [Bring Your Own Runtime](/docs/runtime-mcp#multi-workspace-mode) documents the `MOLECULE_WORKSPACES` env var, cross-workspace tool routing semantics, and back-compat guarantees for single-workspace operators.
+
+---
 ## 2026-04-23
 
 ### ✨ New features

--- a/content/docs/external-agents.mdx
+++ b/content/docs/external-agents.mdx
@@ -26,6 +26,7 @@ stdio server.
 | Your agent runs as | Best path | Why |
 |---|---|---|
 | **An MCP-aware runtime** (Claude Code, Hermes, OpenCode, Cursor, Cline) | [Bring Your Own Runtime (MCP)](/docs/runtime-mcp) | Universal `molecule-mcp` wheel — no HTTP server, no tunnel. |
+| **One agent registered into N workspaces** (e.g. company + personal) | [Multi-workspace mode](/docs/runtime-mcp#multi-workspace-mode) | Single `molecule-mcp` process, `MOLECULE_WORKSPACES` JSON env, peers aggregated across all registered workspaces. |
 | **A Claude Code session on your laptop** | [Claude Code Channel Plugin](/docs/guides/claude-code-channel-plugin) | Polling-based; no tunnel/public URL needed. Set up in under a minute. |
 | Any HTTP server with a public URL | The flow on this page (or the [Python SDK guide](/docs/guides/external-agent-registration)) | Push-based; lower latency; works for any A2A-compatible HTTP endpoint. |
 | A custom A2A server you wrote yourself | The flow on this page | Direct register + heartbeat + handler. |

--- a/content/docs/runtime-mcp.mdx
+++ b/content/docs/runtime-mcp.mdx
@@ -394,6 +394,99 @@ This is the canonical signal that you need to regenerate from the canvas
 don't crash, but every platform-side operation will fail until you
 re-onboard.
 
+## Multi-workspace mode
+
+> **When to use this:** you want **one** running `molecule-mcp` process to
+> register into multiple workspaces — e.g. an agent on a developer's
+> company PC that needs to participate in BOTH the company tenant's
+> workspace AND a personal tenant's workspace at the same time. The
+> single process can then be addressed from either canvas, and
+> `list_peers` aggregates peers across both sides.
+
+### `MOLECULE_WORKSPACES` env var
+
+Set `MOLECULE_WORKSPACES` to a JSON array of `{"id", "token"}` pairs
+instead of `WORKSPACE_ID` + `MOLECULE_WORKSPACE_TOKEN`:
+
+```json title=".mcp.json"
+{
+  "mcpServers": {
+    "molecule": {
+      "type": "stdio",
+      "command": "molecule-mcp",
+      "env": {
+        "PLATFORM_URL": "https://your-tenant.moleculesai.app",
+        "MOLECULE_WORKSPACES": "[{\"id\":\"<company-ws-id>\",\"token\":\"<company-token>\"},{\"id\":\"<personal-ws-id>\",\"token\":\"<personal-token>\"}]"
+      }
+    }
+  }
+}
+```
+
+The shell-friendly form (line breaks for readability — keep it on one
+line in the actual env var):
+
+```bash
+export MOLECULE_WORKSPACES='[
+  {"id": "<company-ws-id>",  "token": "<company-token>"},
+  {"id": "<personal-ws-id>", "token": "<personal-token>"}
+]'
+molecule-mcp
+```
+
+When `MOLECULE_WORKSPACES` is set, the legacy `WORKSPACE_ID` and
+`MOLECULE_WORKSPACE_TOKEN` env vars are **ignored** — the JSON is the
+sole source of truth.
+
+### What changes at runtime
+
+The single `molecule-mcp` process spawns:
+
+- One `register` call per workspace (idempotent — registry no-ops if
+  already registered).
+- One heartbeat thread per workspace, named
+  `molecule-mcp-heartbeat-<src[:8]>` so log correlation is obvious.
+- One inbox poller per workspace. Cursor files are namespaced by
+  workspace id (`.inbox_cursor_<src[:8]>`) so a poller crash in one
+  workspace can't corrupt another's cursor.
+
+Each workspace's bearer token lives in its own slot of the per-workspace
+registry — outbound requests use the source workspace's token + a
+matching `X-Workspace-ID` header, so the platform's TenantGuard always
+sees a consistent (token, source) pair.
+
+### Cross-workspace tool routing
+
+A2A tools accept an optional `source_workspace_id` argument (or
+`workspace_id` for `send_message_to_user`). Defaults are tuned so the
+agent rarely has to set it explicitly:
+
+| Tool | Default source resolution |
+|---|---|
+| `list_peers` | Aggregates peers across **every** registered workspace, prefixing each entry with `via: <src[:8]>` so the agent can tell which side surfaced it. Side effect: populates a peer→source cache used by `delegate_task`. |
+| `delegate_task`, `delegate_task_async` | Auto-route via the cache populated by `list_peers`. Cache miss → fall back to `WORKSPACE_ID` (single-workspace path). |
+| `check_task_status` | Defaults to `WORKSPACE_ID`'s delegation log. Pass `source_workspace_id` to query a different registered workspace. |
+| `send_message_to_user` | Pass `workspace_id` to choose which canvas the message is delivered into. |
+
+Explicit override always wins — pass `source_workspace_id` (or
+`workspace_id`) on any tool call to bypass the auto-route.
+
+### Failure semantics
+
+The process exits non-zero at startup with a human-readable error if
+`MOLECULE_WORKSPACES` is malformed (invalid JSON, missing `id` /
+`token` fields, duplicate workspace ids, or empty array). Same failure
+shape as the single-workspace missing-env error — no half-registered
+state.
+
+### Single-workspace back-compat
+
+If `MOLECULE_WORKSPACES` is unset, behavior is **identical** to before:
+the process reads `WORKSPACE_ID` + `MOLECULE_WORKSPACE_TOKEN` (or
+`${CONFIGS_DIR}/.auth_token`), runs one heartbeat + one inbox poller,
+and the new optional tool args are simply unused. No migration needed
+for existing single-workspace operators.
+
 ## Troubleshooting
 
 ### Workspace stays offline after `/mcp` connect


### PR DESCRIPTION
## Summary

Documents the multi-workspace MCP feature shipped in [molecule-core #2739](https://github.com/Molecule-AI/molecule-core/pull/2739) + [#2743](https://github.com/Molecule-AI/molecule-core/pull/2743). One \`molecule-mcp\` process can now register into N workspaces via a new \`MOLECULE_WORKSPACES\` JSON env var — the company-PC + personal-tenant use case where the same physical agent should be reachable from either canvas, with \`list_peers\` aggregating peers across both sides.

## Changes

- **\`content/docs/runtime-mcp.mdx\`** — new **Multi-workspace mode** section between **Heartbeat & lifecycle** and **Troubleshooting**:
  - env var shape (JSON config + shell form)
  - what changes at runtime (one heartbeat + poller per workspace, namespaced cursor files, isolated bearer tokens)
  - cross-workspace tool routing table (auto-route via the peer→source cache, explicit override semantics)
  - failure semantics (startup hard-fail on malformed JSON / dup ids / empty array)
  - single-workspace back-compat statement
- **\`content/docs/external-agents.mdx\`** — new \"Pick the right path\" row pointing at the multi-workspace section for operators running one agent across N tenants.
- **\`content/docs/changelog.mdx\`** — 2026-05-04 entry covering both shipped MCP PRs AND the [\`molecule-controlplane\` #461](https://github.com/Molecule-AI/molecule-controlplane/pull/461) RFC #388 PR-6 (bake → Railway \`EC2_AMI\` auto-promote) + [#462](https://github.com/Molecule-AI/molecule-controlplane/pull/462) Issue #456 fix (caddy + ssm-agent baked into the thin tenant AMI), so customers see the boot-latency improvement next to the new feature.

## Test plan

- [ ] mdx renders cleanly (\`pnpm dev\` locally)
- [ ] new section heading anchor resolves: \`/docs/runtime-mcp#multi-workspace-mode\`
- [ ] cross-link from \`external-agents.mdx\` resolves to the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)