### PR TITLE
fix(search): restore fumadocs search index — stub returned empty array

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,10 +1,15 @@
-import { NextResponse } from 'next/server';
+// Search route — wires the docs content tree into fumadocs' built-in
+// Orama search index. The previous stub at this path returned an empty
+// array because of a v15.8 fumadocs bug that crashed page collection
+// with `a.map is not a function`. We're on fumadocs-core ^16.7 now;
+// `createFromSource` works against our existing loader without any
+// extra static-collection step, so the stub can go.
 
-// Minimal search endpoint — returns empty results. The fumadocs
-// createFromSource/createSearchAPI both crash on v15.8 with "a.map
-// is not a function" during static page collection. This stub keeps
-// the route alive so the site builds; swap back to the fumadocs
-// search API once the upstream fix lands.
-export function GET() {
-  return NextResponse.json([]);
-}
+import { source } from '@/lib/source';
+import { createFromSource } from 'fumadocs-core/search/server';
+
+// One-line restoration: createFromSource produces { GET } that the
+// search bar (fumadocs-ui's `useDocsSearch` hook) hits at /api/search.
+// No options needed — defaults index title + content of every page in
+// the source tree.
+export const { GET } = createFromSource(source);


### PR DESCRIPTION
## User-flagged problem
The docs site search bar at `doc.moleculesai.app` silently returns no results. Verified by hitting the endpoint directly:

```
curl https://doc.moleculesai.app/api/search?query=mcp
→ HTTP 200, body: `[]`  (always)
```

## Root cause
`app/api/search/route.ts` shipped as a stub:

```ts
// pre-fix
export function GET() {
  return NextResponse.json([]);
}
```

The comment block in the stub explained why: an old fumadocs v15.8 bug where `createFromSource` crashed page collection with `a.map is not a function`. The fix was tagged as "swap back once the upstream fix lands." The fix landed; we're on `fumadocs-core ^16.7.16` per package.json, and `createFromSource` works against our existing loader without any extra static-collection step.

## Fix
One-line restoration to the standard fumadocs pattern:

```ts
import { source } from '@/lib/source';
import { createFromSource } from 'fumadocs-core/search/server';
export const { GET } = createFromSource(source);
```

The fumadocs-ui search bar (the `useDocsSearch` hook used in our DocsLayout) hits this route at `/api/search` and now gets indexed title+content matches across the full content tree.

## Verification
- `tsc --noEmit` clean
- `pnpm build` → all 112 docs pages prerender, /api/search shows as dynamic route (`ƒ`) as expected
- 14 LOC change, 1 file

## Test plan
- [x] Build clean
- [ ] Vercel preview deploy → hit search bar with `mcp`, `workspace`, `platform` and confirm matches
- [ ] CI green

## Out of scope (separate followup)
The user also flagged the broader "docs UX vs MiniMax docs" gap — top-tab nav across major sections, vivid card grid on home, "Copy page" / LLM-context button, on-page TOC polish, top announcement banner. Those are layout/IA changes worth a separate design iteration; this PR keeps scope to the broken-search bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
