### PR TITLE
feat(home): vivid card grid for quick-start lanes (closes MiniMax-comparison gap)

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,29 +1,54 @@
 import Link from 'next/link';
 
-// Three quick-start lanes — keeps the home page from being a wall of text
-// and lets builders, operators, and integrators each find their entry
-// point in one click.
+// Three quick-start lanes, rendered as vivid colored cards instead of
+// thin-border text blocks. Each card pairs a brand-colored "art" panel
+// with title + body below, mirroring the layout pattern that other
+// platform docs (MiniMax, Anthropic, Vercel) use to make the home page
+// scannable in a single glance instead of a wall-of-text.
+//
+// Colors reuse the three accent dots already on the page (kicker dot
+// #c0532b, hero accent #3b5bdb, statusbar dot #2f7a4d) so we're not
+// inventing brand surface here — just exposing it at card scale.
 const lanes = [
   {
     kicker: '01',
     title: 'Build a workspace',
-    body: 'Pick a runtime template (Claude Code, LangGraph, CrewAI, Hermes, …), wire your tools, and ship.',
+    artLabel: 'Workspace',
+    artTagline: 'Runtime + tools + memory',
+    body: 'Pick a runtime template (Claude Code, LangGraph, CrewAI, Hermes, codex, openclaw, …), wire your tools, and ship.',
     href: '/docs/workspace',
-    cta: 'Workspace guide →',
+    cta: 'Workspace guide',
+    // Deep blue → cyan gradient. Pairs with the hero "AI agent organizations"
+    // accent + the canvas chat-bubble blue, so a builder lands on something
+    // tonally familiar.
+    gradient: 'from-[#1e3a8a] via-[#2950c9] to-[#3b82f6]',
   },
   {
     kicker: '02',
     title: 'Run an organisation',
-    body: 'Topology, A2A, three-tier memory, governance — the platform layer that ties multi-agent teams together.',
+    artLabel: 'Platform',
+    artTagline: 'A2A · memory · governance',
+    body: 'Topology, A2A delegation, three-tier memory, governance — the platform layer that ties multi-agent teams together.',
     href: '/docs/platform',
-    cta: 'Platform reference →',
+    cta: 'Platform reference',
+    // Warm amber → orange. Same family as the kicker dot (#c0532b) and
+    // the warm-paper canvas theme — operators reading platform docs are
+    // typically the same people who configure the canvas.
+    gradient: 'from-[#7c2d12] via-[#c0532b] to-[#f59e0b]',
   },
   {
     kicker: '03',
     title: 'Publish to the Marketplace',
+    artLabel: 'Marketplace',
+    artTagline: '80% rev share · signed manifests',
     body: 'Plugins, agents, and org bundles ship as signed manifests. Authors keep 80%, paid via Stripe Connect.',
     href: '/docs/marketplace',
-    cta: 'Author guide →',
+    cta: 'Author guide',
+    // Forest green → emerald. Picks up the statusbar's "All systems"
+    // green so the marketplace lane reads as the "shipped, healthy"
+    // path — and visually distinct from build (cool blue) and run
+    // (warm orange).
+    gradient: 'from-[#14532d] via-[#2f7a4d] to-[#10b981]',
   },
 ];
 
@@ -72,24 +97,54 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Three lanes */}
+      {/* Three lanes — vivid card grid (was thin-border text blocks). */}
       <section className="px-6 pb-24 max-w-6xl mx-auto w-full">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
           {lanes.map((lane) => (
             <Link
               key={lane.kicker}
               href={lane.href}
-              className="group rounded-lg border border-fd-border bg-fd-card p-6 transition hover:border-fd-foreground hover:-translate-y-0.5"
+              className="group flex flex-col overflow-hidden rounded-2xl border border-fd-border bg-fd-card transition hover:-translate-y-1 hover:shadow-lg"
             >
-              <div className="text-[11px] font-mono text-[#3b5bdb] mb-3 tracking-[0.08em]">
-                {lane.kicker}
+              {/* Art panel — brand-gradient with the section name in big
+                  white type. Aspect ratio matches MiniMax / Vercel /
+                  Anthropic card layouts so the home page feels visually
+                  consistent with peer platform docs. */}
+              <div
+                className={`relative aspect-[4/3] bg-gradient-to-br ${lane.gradient} p-6 flex flex-col justify-between text-white`}
+              >
+                {/* Subtle dot-grid overlay so the gradient doesn't look
+                    too flat. opacity-[0.07] keeps it under the title. */}
+                <div
+                  className="absolute inset-0 opacity-[0.07]"
+                  style={{
+                    backgroundImage:
+                      'radial-gradient(circle, currentColor 1px, transparent 1px)',
+                    backgroundSize: '12px 12px',
+                  }}
+                  aria-hidden="true"
+                />
+                <div className="relative text-[11px] font-mono uppercase tracking-[0.12em] opacity-80">
+                  {lane.kicker} · {lane.artLabel}
+                </div>
+                <div className="relative">
+                  <div className="text-3xl sm:text-4xl font-semibold leading-[1.05] mb-1.5">
+                    {lane.title}
+                  </div>
+                  <div className="text-[11px] font-mono uppercase tracking-[0.08em] opacity-80">
+                    {lane.artTagline}
+                  </div>
+                </div>
               </div>
-              <h3 className="text-base font-semibold mb-2">{lane.title}</h3>
-              <p className="text-sm text-fd-muted-foreground leading-relaxed mb-4">
-                {lane.body}
-              </p>
-              <div className="text-xs font-mono text-fd-foreground group-hover:text-[#3b5bdb] transition">
-                {lane.cta}
+
+              {/* Content panel */}
+              <div className="flex flex-1 flex-col justify-between p-5">
+                <p className="text-sm text-fd-muted-foreground leading-relaxed mb-4">
+                  {lane.body}
+                </p>
+                <div className="text-xs font-mono text-fd-foreground group-hover:text-[#3b5bdb] transition">
+                  {lane.cta} →
+                </div>
               </div>
             </Link>
           ))}


### PR DESCRIPTION
## User feedback
*"our docs page looks bad, can you check how other brand docs works? [MiniMax screenshot] looks much better than ours for the layout and ease of use"*

The MiniMax / Vercel / Anthropic docs all use the same pattern: their landing page reads as a **product surface** (vivid colored cards, scannable in one glance) while ours read as a wall of text. This PR closes the gap on the most visible piece — the home page card grid.

## Before vs after

**Before:** thin-border text blocks with kicker + title + body + CTA. Three columns of text. Reads like a wiki.

**After:** vivid gradient art panel on top (section name in big white type, dot-grid overlay), content panel below (description + CTA). aspect-[4/3] art + rounded-2xl + hover lift. Reads like the product.

## Color choices reuse existing brand surface
- **Build a workspace** — blue (`#1e3a8a → #3b82f6`) — matches hero accent + canvas chat bubbles
- **Run an organisation** — amber (`#7c2d12 → #f59e0b`) — matches kicker dot `#c0532b` + warm-paper
- **Publish to Marketplace** — emerald (`#14532d → #10b981`) — matches statusbar "All systems" green

Not inventing new brand color — these three accents already live on the page (kicker dot, hero accent, statusbar dot). Card-scale exposure of what's already there.

## Verification
- `tsc --noEmit` clean
- `pnpm build` clean — all 112 docs pages prerender, /api/search still dynamic (search fix from #125 still in place)
- 93 LOC change (−19 deleted, +74 added), 1 file

## Test plan
- [x] Build clean
- [ ] Vercel preview → land on doc.moleculesai.app, three cards render with brand gradients, hover lifts cards 4px
- [ ] CI green

## Followups (same feedback, separate PRs)
- Section tabs in top nav (replace external Platform/Marketplace/Landing links with internal section anchors like MiniMax's Developer Guides / API Reference / Pricing tabs)
- "Copy page" button next to H1 for LLM-context export
- Top dismissible announcement banner for releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
