### PR TITLE
feat(ci): docs accuracy gate — block stale-symbol PRs at build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      # Self-test runs the deny-list against synthetic deleted-symbol
+      # probes BEFORE checking real content. This catches a regression
+      # where a pattern's regex stops matching the symbol it's meant to
+      # guard against — without it, the gate could silently rot to
+      # always-pass even as new stale refs land.
+      - name: docs accuracy gate (self-test)
+        run: bash scripts/check-stale-refs.sh --self-test
+      - name: docs accuracy gate
+        run: bash scripts/check-stale-refs.sh

--- a/scripts/check-stale-refs.sh
+++ b/scripts/check-stale-refs.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# check-stale-refs.sh — fail the build if docs/content references symbols
+# that have been deleted from the platform. Catches the failure mode where
+# a feature gets removed but its docs page lingers, leading to operators
+# following an obsolete recipe and filing "this doesn't work" bugs.
+#
+# Why a deny-list and not a positive index: maintaining an enumeration of
+# every live API surface is a much bigger change (would need code-side
+# annotations or a generated source-of-truth file). A deny-list catches
+# the specific class — "we deleted X, did we also remove its docs?" — at
+# the cost of one line per deletion. After three months of accrual, the
+# deny-list will be a reliable accuracy gate even without positive
+# indexing.
+#
+# Add a new entry whenever you delete a docs-mentioned symbol, with a
+# `# deleted-in <PR-or-date>:` comment to explain provenance. Order does
+# not matter; the script greps each pattern independently.
+#
+# Run:
+#   bash scripts/check-stale-refs.sh             # exit 0 if clean, 1 if stale
+#   bash scripts/check-stale-refs.sh --self-test # run with synthetic input
+#                                                # to verify each pattern fires
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+CONTENT_DIR="${CONTENT_DIR:-$REPO_ROOT/content}"
+
+# Patterns are bash-extended-regex. Each entry: pattern, then a one-line
+# comment with provenance + remediation hint.
+#
+# Format: PAT|HINT  — split on the first | so HINT can contain anything.
+PATTERNS=(
+  # deleted-in molecule-core#2856 (TeamHandler.Expand backend route).
+  '/workspaces/[^"`)]*expand|expand a team|expand_team|TeamHandler\.Expand|POST.*expand|Expand to Team'
+
+  # deleted-in molecule-core#2917 (TeamHandler.Collapse backend route).
+  '/workspaces/[^"`)]*collapse|collapse_team|TeamHandler\.Collapse|Collapse a team|Collapse team back'
+
+  # deleted-in docs#127 (page rename + content removed).
+  'team-expansion\.md'
+
+  # Wrong canonical hostname. doc.moleculesai.app is the live docs site;
+  # docs.molecule.ai NXDOMAIN. Caught in molecule-core#2932.
+  'docs\.molecule\.ai'
+)
+
+# self-test: run each pattern against a synthetic file containing the
+# deleted symbol, assert each one matches. Catches a regression where
+# an entry's regex accidentally stops matching the symbol it's meant to
+# guard against (typo in pattern, inverted character class, etc.).
+if [ "${1:-}" = "--self-test" ]; then
+  echo "=== self-test ==="
+  fail=0
+  declare -a probes=(
+    'POST /workspaces/abc/expand'
+    'POST /workspaces/abc/collapse'
+    'expand_team mcp tool'
+    'collapse_team mcp tool'
+    'TeamHandler.Expand symbol'
+    'TeamHandler.Collapse symbol'
+    '../agent-runtime/team-expansion.md'
+    'See https://docs.molecule.ai/docs/guides/foo'
+  )
+  for probe in "${probes[@]}"; do
+    matched=0
+    for p in "${PATTERNS[@]}"; do
+      if echo "$probe" | grep -E -q "$p"; then
+        matched=1
+        break
+      fi
+    done
+    if [ "$matched" = "0" ]; then
+      echo "  FAIL: probe NOT caught by any pattern: $probe"
+      fail=1
+    else
+      echo "  ok:   probe caught: $probe"
+    fi
+  done
+  if [ "$fail" != "0" ]; then
+    echo "self-test FAILED — at least one deleted symbol falls through the deny-list."
+    exit 2
+  fi
+  echo "self-test PASSED"
+  exit 0
+fi
+
+# Real check.
+status=0
+total_violations=0
+echo "=== docs accuracy: scanning $CONTENT_DIR ==="
+for pat in "${PATTERNS[@]}"; do
+  # grep -E with --include keeps it on docs content (md, mdx). Excludes
+  # the content/_meta files where pattern strings sometimes appear in
+  # legitimate JSON keys; tighten in future if it bites.
+  matches=$(grep -E -rn --include="*.md" --include="*.mdx" "$pat" "$CONTENT_DIR" 2>/dev/null || true)
+  if [ -n "$matches" ]; then
+    count=$(printf '%s\n' "$matches" | wc -l | tr -d ' ')
+    total_violations=$((total_violations + count))
+    echo
+    echo "::error::$count stale reference(s) match pattern: $pat"
+    printf '%s\n' "$matches" | head -10 | sed 's/^/  /'
+    if [ "$count" -gt 10 ]; then
+      echo "  ... ($((count - 10)) more)"
+    fi
+    status=1
+  fi
+done
+
+if [ "$status" = "0" ]; then
+  echo "OK — no stale references in $CONTENT_DIR"
+fi
+
+if [ "$total_violations" -gt 0 ]; then
+  echo
+  echo "Total violations: $total_violations"
+  echo "Fix: remove the stale reference, or — if it's a comment that intentionally"
+  echo "documents the deletion — narrow the pattern in scripts/check-stale-refs.sh"
+  echo "to exclude the legitimate context."
+fi
+
+exit "$status"


### PR DESCRIPTION
## Why
Closes the loop on the docs#127 stale-Expand/Collapse sweep: instead of catching stale docs by **periodic audit** (which is what we just did), **fail CI** the moment a stale-symbol reference lands in `content/`. Future deletions only need a one-line entry in the deny-list to extend protection.

## Design choice — deny-list, not positive index
Maintaining an enumeration of every live API surface would be a much bigger change (would need code-side annotations or a generated SoT file). The deny-list catches the specific class — *"we deleted X, did we also remove its docs?"* — at the cost of one line per deletion. After a few months of accrual, the deny-list is a reliable accuracy gate even without positive indexing.

## Files

### `scripts/check-stale-refs.sh`
Bash-extended-regex deny-list (4 patterns covering 14 sub-symbols today):
- TeamHandler.Expand surface — `molecule-core#2856`
- TeamHandler.Collapse surface — `molecule-core#2917`
- `team-expansion.md` file-name reference — `docs#127`
- `docs.molecule.ai` (NXDOMAIN) — `molecule-core#2932`

`--self-test` flag: runs each pattern against a synthetic deleted-symbol probe and asserts EVERY probe is caught. Pin the *"this gate is not vestigial"* invariant — a future pattern-edit that silently stops matching its target would otherwise let stale refs ship undetected.

### `.github/workflows/ci.yml`
Two new build steps:
- `docs accuracy gate (self-test)` — synthetic probes BEFORE the real check.
- `docs accuracy gate` — real run against `content/`.

## Verification
| Test | Expected | Got |
|---|---|---|
| self-test | 8/8 probes caught, exit 0 | ✓ |
| real run on current content/ | 0 violations, exit 0 | ✓ |
| synthetic stale-ref insertion | violations detected, exit 1 | ✓ |
| YAML lint | clean | ✓ |

## How to extend
When deleting a docs-mentioned symbol:
1. Append a regex to `PATTERNS` in the script with a `# deleted-in <PR>` provenance comment.
2. Add a probe to the self-test array so the regex is verified against the symbol shape it's meant to guard.
3. CI will block any PR that re-introduces the deleted symbol into `content/`.

132 LOC across 2 files. Ships the *"keep documentations up to date"* directive proactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
