### PR TITLE
feat(ci): broken-link gate + fix 14 existing broken cross-links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,14 @@ jobs:
         run: bash scripts/check-stale-refs.sh --self-test
       - name: docs accuracy gate
         run: bash scripts/check-stale-refs.sh
+      # Broken-link gate — pairs with the stale-refs gate above. The
+      # stale-refs check catches symbol references that should have
+      # been deleted; this one catches link targets that moved or
+      # never existed (the fumadocs build doesn't fail on broken
+      # cross-links — they render as visible "broken text" once a
+      # user clicks). Self-test runs first to verify the resolver
+      # itself; real run follows.
+      - name: docs broken-link gate (self-test)
+        run: python3 scripts/check-broken-links.py --self-test
+      - name: docs broken-link gate
+        run: python3 scripts/check-broken-links.py

--- a/content/docs/agent-runtime/agent-card.md
+++ b/content/docs/agent-runtime/agent-card.md
@@ -81,7 +81,6 @@ When a peer workspace receives `AGENT_CARD_UPDATED`, it rebuilds its system prom
 
 ## Related Docs
 
-- [Core Concepts](../product/core-concepts.md) — What an Agent Card is
 - [A2A Protocol](../api-protocol/a2a-protocol.md) — How the card fits into A2A
 - [Workspace Runtime](./workspace-runtime.md) — How the card is generated at startup
 - [Canvas UI](../frontend/canvas.md) — How the card drives node rendering

--- a/content/docs/development/constraints-and-rules.md
+++ b/content/docs/development/constraints-and-rules.md
@@ -80,7 +80,6 @@ Postgres and Redis must not expose host ports. They communicate exclusively over
 
 ## Related Docs
 
-- [SaaS Upgrade Path](../product/saas-upgrade.md) — How auth and multi-tenancy are added
 - [Bundle System](../agent-runtime/bundle-system.md) — Why bundles exclude secrets
 - [Event Log](../architecture/event-log.md) — The append-only rule
 - [Communication Rules](../api-protocol/communication-rules.md) — Hierarchy = access control

--- a/content/docs/glossary.md
+++ b/content/docs/glossary.md
@@ -11,7 +11,7 @@ defines how Molecule AI uses each term and flags the conflicts you're
 most likely to hit when reading adjacent documentation.
 
 Cross-referenced from
-[`docs/ecosystem-watch.md`](./ecosystem-watch.md) — when a new project
+`docs/ecosystem-watch.md` — when a new project
 lands in the watch list with a colliding term, add a row here.
 
 ## Core terms
@@ -67,7 +67,7 @@ two:
 
 ## Cross-references
 
-- [`README.md`](../README.md) — top-level stack description.
-- [`CLAUDE.md`](../CLAUDE.md) — operational vocabulary for agents in this repo.
-- [`docs/ecosystem-watch.md`](./ecosystem-watch.md) — source of truth for adjacent-project claims.
-- [`docs/architecture.md`](./architecture.md) — deeper definitions for workspace, canvas, platform.
+- [`README.md`](../../README.md) — top-level stack description.
+- [`CLAUDE.md`](../../CLAUDE.md) — operational vocabulary for agents in this repo.
+- `docs/ecosystem-watch.md` — source of truth for adjacent-project claims.
+- [`docs/architecture.md`](./architecture.mdx) — deeper definitions for workspace, canvas, platform.

--- a/content/docs/guides/skill-catalog.md
+++ b/content/docs/guides/skill-catalog.md
@@ -210,7 +210,6 @@ contains valid Python files with `@tool`-decorated functions. See
   frontmatter schema, and tool interface
 - [Config Format](../agent-runtime/config-format.md) — How skills are
   declared in `config.yaml`
-- [Plugin System](../plugins/overview.md) — Installing full plugin
   packages (skills + MCP servers + shared rules)
 - [Remote Agent Tutorial](../tutorials/register-remote-agent.md) —
   Installing skills on remote (external) agents

--- a/content/docs/tutorials/fly-machines-provisioner.md
+++ b/content/docs/tutorials/fly-machines-provisioner.md
@@ -104,5 +104,5 @@ Fly Machines start in milliseconds and run in 35+ regions. Provisioning agent wo
 - PR #501: [feat(platform): Fly Machines provisioner](https://github.com/Molecule-AI/molecule-core/pull/501)
 - PR #481: [feat(ci): deploy to Fly after image push](https://github.com/Molecule-AI/molecule-core/pull/481)
 - [Fly Machines API docs](https://fly.io/docs/machines/api/)
-- [Platform API reference](../api-reference.md)
+- [Platform API reference](../api-reference.mdx)
 - Issue [#525](https://github.com/Molecule-AI/molecule-core/issues/525)

--- a/content/docs/tutorials/gemini-cli-runtime.md
+++ b/content/docs/tutorials/gemini-cli-runtime.md
@@ -65,5 +65,4 @@ The real power surfaces when you mix runtimes on the same Molecule AI tenant. Yo
 ## Related
 
 - PR #379: [feat(adapters): add gemini-cli runtime adapter](https://github.com/Molecule-AI/molecule-core/pull/379)
-- [Multi-provider Hermes docs](../architecture/hermes.md)
-- [Workspace runtimes reference](../reference/runtimes.md)
+- [Multi-provider Hermes docs](../hermes.mdx)

--- a/content/docs/tutorials/google-adk-runtime.md
+++ b/content/docs/tutorials/google-adk-runtime.md
@@ -74,4 +74,4 @@ ADK workspaces participate in the same A2A network as Claude Code, Gemini CLI, H
 - PR #550: [feat(adapters): add google-adk runtime adapter](https://github.com/Molecule-AI/molecule-core/pull/550)
 - [Google ADK (adk-python)](https://github.com/google/adk-python)
 - [Gemini CLI runtime tutorial](./gemini-cli-runtime.md)
-- [Platform API reference](../api-reference.md)
+- [Platform API reference](../api-reference.mdx)

--- a/content/docs/tutorials/hermes-multi-provider-dispatch.md
+++ b/content/docs/tutorials/hermes-multi-provider-dispatch.md
@@ -183,5 +183,5 @@ What is on the roadmap for Phase 2d (not yet shipped):
 - PR #255: [Phase 2b — native Gemini dispatch](https://github.com/Molecule-AI/molecule-core/pull/255)
 - PR #267: [Phase 2c — multi-turn history on all paths](https://github.com/Molecule-AI/molecule-core/pull/267)
 - [Hermes adapter design](../adapters/hermes-adapter-design.md)
-- [Platform API reference](../api-reference.md)
+- [Platform API reference](../api-reference.mdx)
 - Issue [#513](https://github.com/Molecule-AI/molecule-core/issues/513)

--- a/content/docs/tutorials/lark-feishu-channel.md
+++ b/content/docs/tutorials/lark-feishu-channel.md
@@ -95,4 +95,4 @@ Molecule AI canvas without code changes.
 
 - PR #480: [feat(channels): Lark / Feishu channel adapter](https://github.com/Molecule-AI/molecule-core/pull/480)
 - [Social channels architecture](../agent-runtime/social-channels.md)
-- [Channel adapter reference](../api-reference.md#channels)
+- [Channel adapter reference](../api-reference.mdx#channels)

--- a/scripts/check-broken-links.py
+++ b/scripts/check-broken-links.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+check-broken-links.py — fail the build if any markdown file in content/
+links to an internal target that doesn't exist on disk.
+
+Catches the failure mode where a doc gets renamed/deleted and back-
+references in other docs are missed (the fumadocs build doesn't fail
+on broken cross-links — it just renders them as visible "broken text"
+once the user clicks).
+
+This pairs with check-stale-refs.sh: that script catches symbol
+references that should be deleted; this one catches link targets that
+moved or never existed. Together they cover the two main classes of
+"docs got out of sync" drift.
+
+Algorithm:
+  - Walk content/**/*.{md,mdx}.
+  - For each `[text](./rel/path.md)` or `[text](../rel/path.mdx)` link
+    where the target ends in .md or .mdx and is a relative path
+    (starting with ./ or ../).
+  - Resolve target relative to the source file's directory.
+  - If the resolved path is INSIDE content/ AND doesn't exist, fail.
+  - If the resolved path escapes content/ (e.g. ../../README.md to the
+    repo root), skip — those go through git/repo conventions and are
+    out of scope for the docs-site build.
+
+Run:
+  python3 scripts/check-broken-links.py            # exit 0 clean, 1 broken
+  python3 scripts/check-broken-links.py --self-test
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTENT = REPO_ROOT / "content"
+
+# Match `](./...)` or `](../...)` for .md / .mdx targets. Greedy at
+# the open-paren but stops before # or ? so anchor / query suffixes
+# don't bleed into the captured path.
+LINK_RE = re.compile(r"\]\((\.{1,2}/[^)#?]+\.mdx?)([)#?])")
+
+
+def find_broken(content_dir: Path) -> list[str]:
+    """Return a list of human-readable broken-link descriptions."""
+    out: list[str] = []
+    for md in sorted([*content_dir.rglob("*.md"), *content_dir.rglob("*.mdx")]):
+        try:
+            text = md.read_text(errors="ignore")
+        except OSError as e:
+            out.append(f"{md}: read error: {e}")
+            continue
+        for m in LINK_RE.finditer(text):
+            rel = m.group(1)
+            target = (md.parent / rel).resolve()
+            # Skip out-of-tree links; those resolve via filesystem
+            # conventions (repo root README, monorepo siblings) and
+            # aren't part of the docs build.
+            try:
+                target.relative_to(content_dir.resolve())
+            except ValueError:
+                continue
+            if not target.exists():
+                # Re-derive line number for friendlier output.
+                line = text[: m.start()].count("\n") + 1
+                rel_md = md.relative_to(REPO_ROOT)
+                out.append(f"{rel_md}:{line} → {rel} (resolves to {target})")
+    return out
+
+
+def self_test() -> int:
+    """Pin the resolver against synthetic inputs.
+
+    Drops a temp .md file inside content/ that references a known-bogus
+    path; the resolver should flag it. Then drops a sibling that does
+    point at a real file; should be ignored. The temp files are cleaned
+    up regardless of pass/fail.
+    """
+    import tempfile
+
+    print("=== self-test ===")
+    fail = 0
+
+    # Resolve a known-existing target so the negative-case probe doesn't
+    # accidentally match the broken-link list.
+    real_target = next(CONTENT.rglob("*.md"), None)
+    if real_target is None:
+        print("  FAIL: no .md files in content/ to use as a real target")
+        return 2
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="brokenlink-selftest-", dir=CONTENT))
+    try:
+        bogus = tmp_dir / "_bogus_probe.md"
+        bogus.write_text(
+            "synthetic test file\n"
+            "[broken](./does-not-exist.md)\n"
+            f"[real]({Path('..') / real_target.relative_to(CONTENT)})\n"
+        )
+        broken = find_broken(CONTENT)
+        bogus_lines = [b for b in broken if "_bogus_probe.md" in b]
+        bogus_broken = [b for b in bogus_lines if "does-not-exist.md" in b]
+        bogus_real_falsepos = [b for b in bogus_lines if str(real_target.name) in b]
+
+        if not bogus_broken:
+            print("  FAIL: synthetic broken link to ./does-not-exist.md NOT caught")
+            fail = 1
+        else:
+            print("  ok: synthetic broken link caught")
+
+        if bogus_real_falsepos:
+            print(f"  FAIL: real existing target {real_target} flagged as broken (false positive):")
+            for b in bogus_real_falsepos:
+                print(f"    {b}")
+            fail = 1
+        else:
+            print("  ok: real existing target not flagged")
+    finally:
+        # Clean up — never leave probe files behind even if the test
+        # bails partway.
+        for p in tmp_dir.glob("*"):
+            p.unlink()
+        tmp_dir.rmdir()
+
+    if fail:
+        print("self-test FAILED")
+        return 2
+    print("self-test PASSED")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        return self_test()
+
+    print(f"=== docs broken-link check: scanning {CONTENT} ===")
+    broken = find_broken(CONTENT)
+    if not broken:
+        print("OK — no broken internal links")
+        return 0
+
+    print()
+    for b in broken[:50]:
+        print(f"::error::broken link: {b}")
+    if len(broken) > 50:
+        print(f"  ... ({len(broken) - 50} more)")
+    print()
+    print(f"Total broken: {len(broken)}")
+    print(
+        "Fix: rename the link to the correct target, or remove the link if the "
+        "target was intentionally deleted. Use .mdx if the actual file is .mdx — "
+        "this is the most common cause."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why
Pairs with the stale-refs gate (#128). That one catches *symbol references that should have been deleted*; this one catches *link targets that moved or never existed*. fumadocs renders broken internal cross-links as visible "broken text" once a user clicks — the **build doesn't fail**. A doc rename or page deletion can leave broken links in N other docs and ship green.

This sweep audited every `[text](./rel/path.md)` and `(.../path.mdx)` link in `content/`. **14 broken targets found**, all fixed in the same PR.

## 14 existing broken links fixed

**Extension mismatches** (`.md` written, file is actually `.mdx`):
- 4× tutorials/* → `../api-reference.md` → `../api-reference.mdx`
- `tutorials/gemini-cli-runtime` → `../architecture/hermes.md` → `../hermes.mdx`
- `glossary.md` → `./architecture.md` → `./architecture.mdx` (×2)

**Up-path mistakes** (`../README.md` from inside `content/docs/` resolves to `content/README.md` — a non-existent file; the writer meant the repo-root README):
- `glossary.md` → `../README.md` → `../../README.md` (×2)
- `glossary.md` → `../CLAUDE.md` → `../../CLAUDE.md` (×2)

**Targets that don't exist anywhere** (link removed; "Related Docs" bullet removed where applicable):
- `glossary.md` → `./ecosystem-watch.md` (×3)
- `constraints-and-rules.md` → `../product/saas-upgrade.md`
- `skill-catalog.md` → `../plugins/overview.md`
- `gemini-cli-runtime.md` → `../reference/runtimes.md`
- `agent-card.md` → `../product/core-concepts.md`

## Gate
`scripts/check-broken-links.py` — Python (pathlib resolves `../../` cleanly):
- Walk every `.md`/`.mdx` in `content/`
- Match `](./...)` or `](../...)` for `.md`/`.mdx` targets
- Resolve relative to source file's dir
- Skip if target escapes `content/` (out-of-tree goes through git/repo conventions, not the docs build)
- Fail with line numbers + resolved paths

`--self-test` drops a temp probe file inside `content/` with a known-broken link AND a known-good link, asserts both behaviors, cleans up regardless of pass/fail. Pins the resolver against future regressions — same pattern as #128's stale-refs self-test.

Two new CI steps in `ci.yml`: self-test → real run.

## Verification
| Test | Got |
|---|---|
| self-test (synthetic broken caught, good not flagged) | ✓ |
| real run on cleaned content/ | 0 broken (was 14) |
| YAML lint | ✓ |

180 LOC across 11 files (mostly link fixes; gate is 159 LOC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
