### PR TITLE
feat(docs): /llms.txt manifest + /llms-full.txt corpus export

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,58 @@
+// /llms-full.txt — concatenated full-text export of every docs page.
+// Companion to /llms.txt (manifest). An LLM agent that wants the
+// whole corpus in one paste — for fine-tuning, retrieval indexing,
+// or "answer questions only from this knowledge base" — fetches
+// here and gets it.
+//
+// Each page is rendered as:
+//
+//   # <title>
+//   <URL>
+//
+//   <raw .md/.mdx body>
+//
+//   ---
+//
+// So an LLM can split on the `---` boundary if it needs per-page
+// chunks, or treat the whole thing as one big context.
+//
+// Pairs with /llms.txt (manifest) and /api/docs-raw/<slug> (per-page
+// exports). Static SSG — the build pre-generates this once, no
+// per-request cost.
+
+import { source } from '@/lib/source';
+
+export const dynamic = 'force-static';
+
+export async function GET() {
+  const pages = source.getPages();
+  // Sort by URL for deterministic output — same ordering as /llms.txt.
+  const sorted = [...pages].sort((a, b) => a.url.localeCompare(b.url));
+
+  const chunks: string[] = [];
+  for (const p of sorted) {
+    let raw: string;
+    try {
+      raw = await p.data.getText('raw');
+    } catch (err) {
+      // A single unreadable page shouldn't break the whole corpus
+      // export. Surface the failure inline so an LLM consumer can see
+      // which page is missing rather than silently dropping it.
+      raw = `<error: could not read source — ${err instanceof Error ? err.message : String(err)}>`;
+    }
+    chunks.push(`# ${p.data.title || p.url}`);
+    chunks.push(p.url);
+    chunks.push('');
+    chunks.push(raw.trim());
+    chunks.push('');
+    chunks.push('---');
+    chunks.push('');
+  }
+
+  return new Response(chunks.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,82 @@
+// /llms.txt — LLM-friendly docs manifest. Standard convention (Vercel,
+// Anthropic, Stripe, et al.) that lets an LLM agent crawl a site's
+// docs efficiently: title + description + URL per page, plain text,
+// no HTML/JS. Pairs with the per-page .md exports at /api/docs-raw/*
+// (PR #130) — the manifest tells the LLM what's available; the .md
+// exports give it the body.
+//
+// Format follows https://llmstxt.org/ — a minimal markdown spec:
+//
+//   # <Site name>
+//   > <One-line description>
+//
+//   ## Section
+//   - [Title](URL): description
+//
+// fumadocs' `source.getPages()` returns the full doc tree; we group
+// by the first slug segment so the manifest reads as
+// "Architecture / Workspace / API Reference / ..." rather than a
+// flat 100-line dump.
+
+import { source } from '@/lib/source';
+
+export const dynamic = 'force-static';
+
+const SITE_TITLE = 'Molecule AI Documentation';
+const SITE_TAGLINE =
+  'The operating system for AI agent organizations. Templates, plugins, channels, runtimes, governance — documented end to end.';
+
+export function GET() {
+  const pages = source.getPages();
+
+  // Group pages by first slug segment. Pages at the docs root (slug
+  // length 0 or 1) go in an "Overview" bucket so they're not lost.
+  const buckets = new Map<string, typeof pages>();
+  for (const p of pages) {
+    const top = (p.slugs ?? [])[0] ?? '_overview';
+    if (!buckets.has(top)) buckets.set(top, []);
+    buckets.get(top)!.push(p);
+  }
+
+  // Sort sections alphabetically, with _overview surfaced first.
+  const orderedSections = [...buckets.keys()].sort((a, b) => {
+    if (a === '_overview') return -1;
+    if (b === '_overview') return 1;
+    return a.localeCompare(b);
+  });
+
+  const lines: string[] = [];
+  lines.push(`# ${SITE_TITLE}`);
+  lines.push('');
+  lines.push(`> ${SITE_TAGLINE}`);
+  lines.push('');
+
+  for (const section of orderedSections) {
+    const sectionPages = buckets.get(section)!;
+    // Section header — title-case the slug, replace hyphens with spaces.
+    const heading =
+      section === '_overview'
+        ? 'Overview'
+        : section
+            .split('-')
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(' ');
+    lines.push(`## ${heading}`);
+    lines.push('');
+    // Sort pages within a section by their URL for deterministic output.
+    sectionPages.sort((a, b) => a.url.localeCompare(b.url));
+    for (const p of sectionPages) {
+      const title = p.data.title || p.url;
+      const desc = p.data.description ? `: ${p.data.description}` : '';
+      lines.push(`- [${title}](${p.url}.md)${desc}`);
+    }
+    lines.push('');
+  }
+
+  return new Response(lines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, must-revalidate',
+    },
+  });
+}


### PR DESCRIPTION
## Why
Standard LLM-friendly-docs convention ([llmstxt.org](https://llmstxt.org/)). Peer docs sites — Vercel, Anthropic, Stripe, Cloudflare — all publish these endpoints so an LLM agent can crawl the site efficiently:

- `/llms.txt` — manifest (title + URL + description per page)
- `/llms-full.txt` — concatenated body of every page

Pairs with the per-page `.md` exports from #130 — manifest tells the LLM what's available; .md exports give it the body; full corpus is one paste for offline retrieval indexing.

## Implementation

### `app/llms.txt/route.ts` — manifest
Groups by first slug segment so the output reads as a Table of Contents ("Architecture / Workspace / API Reference / ...") rather than a flat 100-line dump. Pages at the docs root surface first under "Overview". Format follows llmstxt.org's minimal spec:
```
# Molecule AI Documentation
> The operating system for AI agent organizations...

## Adapters
- [Hermes Adapter — Shell Design Spec](/docs/adapters/hermes-adapter-design.md)
- [Hermes Adapter — Implementation Plan](/docs/adapters/hermes-adapter-plan.md)
...
```

### `app/llms-full.txt/route.ts` — corpus
Concatenates raw .md/.mdx source for every page. Per-page header (title + URL), pages separated by `---` so an LLM can split for chunked retrieval. Single unreadable page surfaces inline as `<error: ...>` rather than silently drops.

Both routes are static SSG (`force-static`) — built once, no per-request cost.

## Verification
- `tsc --noEmit` clean
- `pnpm build` clean — both routes registered as `○ Static`:
  ```
  ├ ○ /llms-full.txt
  └ ○ /llms.txt
  ```
- Sampled `/llms.txt` body: sectioned ToC, title-cased, sorted, descriptions inline.

## Followups
- Link `/llms.txt` from the site footer or `robots.txt` so crawlers find it without prior knowledge.

140 LOC across 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
