### PR TITLE
fix(docs): home-card hrefs 404 → point at real pages + add gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,9 @@ jobs:
         run: python3 scripts/check-broken-links.py --self-test
       - name: docs broken-link gate
         run: python3 scripts/check-broken-links.py
+      # Home-card href gate — narrower than broken-link (one file,
+      # ~3 hrefs) but high-value: home cards are the most-clicked
+      # surface on the site, a 404 here is the worst place for one.
+      # Caught the /docs/workspace + /docs/platform 404s on 2026-05-05.
+      - name: docs home-card href gate
+        run: python3 scripts/check-home-hrefs.py

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -16,8 +16,10 @@ const lanes = [
     artLabel: 'Workspace',
     artTagline: 'Runtime + tools + memory',
     body: 'Pick a runtime template (Claude Code, LangGraph, CrewAI, Hermes, codex, openclaw, …), wire your tools, and ship.',
-    href: '/docs/workspace',
-    cta: 'Workspace guide',
+    // /docs/workspace doesn't exist as a slug; /docs/quickstart is
+    // the actual "first agent deployed" guide a builder lands on.
+    href: '/docs/quickstart',
+    cta: 'Quickstart guide',
     // Deep blue → cyan gradient. Pairs with the hero "AI agent organizations"
     // accent + the canvas chat-bubble blue, so a builder lands on something
     // tonally familiar.
@@ -29,8 +31,10 @@ const lanes = [
     artLabel: 'Platform',
     artTagline: 'A2A · memory · governance',
     body: 'Topology, A2A delegation, three-tier memory, governance — the platform layer that ties multi-agent teams together.',
-    href: '/docs/platform',
-    cta: 'Platform reference',
+    // /docs/platform doesn't exist as a slug; /docs/architecture is
+    // the platform-layer topology + governance overview.
+    href: '/docs/architecture',
+    cta: 'Architecture overview',
     // Warm amber → orange. Same family as the kicker dot (#c0532b) and
     // the warm-paper canvas theme — operators reading platform docs are
     // typically the same people who configure the canvas.

--- a/scripts/check-home-hrefs.py
+++ b/scripts/check-home-hrefs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+check-home-hrefs.py — verify every internal /docs/<slug> href in the
+home page (`app/(home)/page.tsx`) resolves to an actual content file.
+
+Catches the "vivid card on the home page links to a 404 page" failure
+mode that the broader broken-link gate doesn't catch — that gate
+walks `content/**`, but the home cards live in `app/`.
+
+This gate is narrower (one file, one regex) but high-value because
+the home cards are the most-clicked surface on the site. A 404 here
+is the worst place for one to be.
+
+Run:
+  python3 scripts/check-home-hrefs.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOME_FILE = REPO_ROOT / "app" / "(home)" / "page.tsx"
+CONTENT = REPO_ROOT / "content"
+
+# Match `href: '/docs/<path>'` in the home page's lanes config.
+# Single OR double quotes; ignore /api/, anchor-only, or external
+# (https?:) hrefs.
+HREF_RE = re.compile(r"""href:\s*['"](/docs/[^'"#?]*)['"]""")
+
+
+def slug_to_paths(slug: str) -> list[Path]:
+    """Map /docs/foo or /docs/foo/bar to candidate content/ files."""
+    rel = slug.removeprefix("/docs/")
+    if rel == "":
+        return [CONTENT / "docs" / "index.md", CONTENT / "docs" / "index.mdx"]
+    base = CONTENT / "docs" / rel
+    return [
+        base.with_suffix(".md"),
+        base.with_suffix(".mdx"),
+        base / "index.md",
+        base / "index.mdx",
+    ]
+
+
+def main() -> int:
+    if not HOME_FILE.exists():
+        print(f"::error::home page not found at {HOME_FILE}", file=sys.stderr)
+        return 2
+
+    src = HOME_FILE.read_text()
+    hrefs = HREF_RE.findall(src)
+    if not hrefs:
+        print(f"::error::no /docs/* hrefs found in {HOME_FILE}; gate misconfigured?", file=sys.stderr)
+        return 2
+
+    print(f"=== home-href check: {len(hrefs)} hrefs in {HOME_FILE.relative_to(REPO_ROOT)} ===")
+    bad: list[tuple[str, list[Path]]] = []
+    for h in hrefs:
+        candidates = slug_to_paths(h)
+        if not any(p.exists() for p in candidates):
+            bad.append((h, candidates))
+            print(f"  ✗ {h}")
+            for p in candidates:
+                print(f"      tried: {p.relative_to(REPO_ROOT)}")
+        else:
+            for p in candidates:
+                if p.exists():
+                    print(f"  ✓ {h} → {p.relative_to(REPO_ROOT)}")
+                    break
+
+    if bad:
+        print()
+        print(f"::error::{len(bad)} home-page card href(s) point at non-existent docs.")
+        print("Fix: update the `href:` in app/(home)/page.tsx to a real /docs/<slug> path,")
+        print("or create the missing content file.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## User-flagged
2 of the 3 vivid cards on the home page link to slugs that don't exist. Both 404 in production:

| Card | Old href | Status |
|---|---|---|
| Build a workspace | `/docs/workspace` | **404** |
| Run an organisation | `/docs/platform` | **404** |
| Publish to the Marketplace | `/docs/marketplace` | 200 ✓ |

## Fix
Re-target to slugs that exist + match the card's intent:

| Card | New href | Why |
|---|---|---|
| Build a workspace | `/docs/quickstart` | The literal "first agent deployed" guide |
| Run an organisation | `/docs/architecture` | Platform-layer topology + governance |
| Publish to the Marketplace | `/docs/marketplace` | unchanged |

CTA labels updated to match the new targets.

## Gate
`scripts/check-home-hrefs.py` — narrower than the broken-link gate (#129) but high-value: home cards are the most-clicked surface; a 404 here is the worst place for one. The broader gate walks `content/**` and doesn't see hrefs in `app/`.

The script reads `app/(home)/page.tsx`, greps every `href: '/docs/<slug>'`, and checks for matching `.md` / `.mdx` / `/index.md` / `/index.mdx` content files. Wired into ci.yml as a third docs-accuracy step alongside stale-refs (#128) and broken-link (#129).

## Verification
- All 3 hrefs resolve: ✓
- Manual regression: revert one href to `/docs/workspace` → gate exits 1; restore → exit 0.
- YAML lint clean
- pnpm build clean

97 LOC: 12 in page.tsx (hrefs + comments + CTA labels), 6 in ci.yml, 79 in the new gate script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
