### PR TITLE
feat(docs): notebook layout with horizontal section tabs (MiniMax-style)

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,12 +1,56 @@
-import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+// Notebook layout — replaces the prior `fumadocs-ui/layouts/docs`
+// with the notebook variant so the docs site has a horizontal
+// section-tab strip across the top, matching MiniMax / Vercel /
+// Anthropic / Stripe docs patterns.
+//
+// Each tab points at a real page that exists in content/docs and
+// detects "active" via the URL match — if you're on
+// /docs/architecture/provisioner the "Run" tab highlights, etc.
+// The sidebar grouping in content/docs/meta.json is what gives
+// each tab a recognisable scope when the user lands on it.
+
+import { DocsLayout } from 'fumadocs-ui/layouts/notebook';
 import type { ReactNode } from 'react';
+import type { LayoutTab } from 'fumadocs-ui/layouts/shared';
 import { baseOptions } from '@/app/layout.config';
 import { source } from '@/lib/source';
+
+// Each entry maps to one of the meta.json section groups so the
+// horizontal strip gives users a one-click hop into the major
+// areas of the docs without scrolling the sidebar. Order matches
+// the home-card narrative: Build → Run → Reference → Marketplace.
+const tabs: LayoutTab[] = [
+  {
+    title: 'Build',
+    description: 'Workspaces, runtimes, plugins, channels',
+    url: '/docs/quickstart',
+  },
+  {
+    title: 'Run',
+    description: 'Architecture, A2A, governance, ops',
+    url: '/docs/architecture',
+  },
+  {
+    title: 'API Reference',
+    description: 'Platform endpoints, MCP server, SDKs',
+    url: '/docs/api-reference',
+  },
+  {
+    title: 'Marketplace',
+    description: 'Author plugins, agents, org bundles',
+    url: '/docs/marketplace',
+  },
+  {
+    title: 'Changelog',
+    description: 'Releases and breaking changes',
+    url: '/docs/changelog',
+  },
+];
 
 export default function Layout({ children }: { children: ReactNode }) {
   const tree = source.pageTree;
   return (
-    <DocsLayout tree={tree} {...baseOptions}>
+    <DocsLayout tree={tree} tabs={tabs} {...baseOptions}>
       {children}
     </DocsLayout>
   );


### PR DESCRIPTION
## Why
Final layout-parity step against MiniMax / Vercel / Anthropic / Stripe. Their chrome runs a **horizontal section-tab strip** across the top of every doc page; ours had only the sidebar. The user's MiniMax screenshot showed it explicitly.

## Implementation
Switches `app/docs/layout.tsx` from `fumadocs-ui/layouts/docs` to `fumadocs-ui/layouts/notebook` and defines five tabs:

| Tab | URL | Description |
|---|---|---|
| Build | `/docs/quickstart` | Workspaces, runtimes, plugins, channels |
| Run | `/docs/architecture` | Architecture, A2A, governance, ops |
| API Reference | `/docs/api-reference` | Platform endpoints, MCP server, SDKs |
| Marketplace | `/docs/marketplace` | Author plugins, agents, org bundles |
| Changelog | `/docs/changelog` | Releases and breaking changes |

Order matches the home-card narrative (`Build → Run → Reference → Marketplace → Changelog`). Each tab points at a page that exists in `content/docs` (gate-checkable). Active tab detected via URL prefix — deep routes like `/docs/architecture/provisioner` correctly highlight `Run`.

The sidebar continues to render the full `meta.json` tree (this fumadocs version doesn't auto-filter sidebar to per-tab subtrees); the section-divider grouping from #133 is what gives each tab a recognisable sidebar scope.

## Verification
- `tsc --noEmit` clean
- `pnpm build` clean
- **All three docs-accuracy gates still pass:** stale-refs ✓, broken-link ✓, home-hrefs ✓
- 53 LOC change, 1 file (layout swap + tabs config)

## Followups
- **Per-tab sidebar filtering** (fumadocs source `transform` hook) so each tab shows only its own subtree — fully matches MiniMax.
- **Announcement banner** pinned above the tab strip for releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
