### PR TITLE
fix(docs): drop redundant top-nav links + restore Marketplace SaaS link (self-review of #133 + #134)

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -41,20 +41,19 @@ export const baseOptions: BaseLayoutProps = {
     ),
     url: 'https://doc.moleculesai.app',
   },
-  // Top-nav links — internal docs sections first (mirrors the
-  // MiniMax / Vercel / Anthropic pattern of major-section anchors at
-  // the top), then external app surfaces. The internal four match
-  // the section dividers in `content/docs/meta.json` so the user has
-  // a one-click hop into each major section without scrolling the
-  // full sidebar.
+  // Top-nav links — external-app destinations only. Internal section
+  // anchors live in the notebook layout's horizontal `tabs` config
+  // (app/docs/layout.tsx); having both here AND there would render
+  // the same five destinations (Quickstart / Architecture / API /
+  // Marketplace / Changelog) twice in the chrome.
+  //
+  // Both Marketplace surfaces are reachable: the internal docs page
+  // via the "Marketplace" tab; the external Marketplace SaaS app via
+  // the dropdown below.
   links: [
-    { text: 'Quickstart', url: '/docs/quickstart' },
-    { text: 'Architecture', url: '/docs/architecture' },
-    { text: 'API Reference', url: '/docs/api-reference' },
-    { text: 'Marketplace', url: '/docs/marketplace' },
-    { text: 'Changelog', url: '/docs/changelog' },
     { type: 'menu', text: 'Open app', items: [
       { text: 'Platform', url: 'https://app.moleculesai.app', external: true },
+      { text: 'Marketplace', url: 'https://market.moleculesai.app', external: true },
       { text: 'Landing', url: 'https://www.moleculesai.app', external: true },
     ] },
   ],


### PR DESCRIPTION
## Self-review findings

Caught running /code-review-and-quality on the in-flight chrome PRs:

### 1. Important — #133 + #134 redundancy
Both PRs add the same 5 destinations to the chrome:
- #133 as top-nav `links:`
- #134 as horizontal section `tabs`

When both deploy, users see Quickstart / Architecture / API Reference / Marketplace / Changelog rendered **twice** in the chrome — once as nav links, once as the tab strip. Real UX confusion bug.

### 2. Important — Marketplace SaaS link regression in #133
The original `links:` array had `{ text: 'Marketplace', url: 'https://market.moleculesai.app' }` — the actual Marketplace **SaaS app**. #133 replaced that with `{ text: 'Marketplace', url: '/docs/marketplace' }` (docs ABOUT the marketplace) — different surface. Users lost the chrome path to the SaaS app.

## Fix

This PR removes the 5 internal anchors from `links:` (now lives in tabs only) and adds back `market.moleculesai.app` as a third entry in the "Open app ▾" dropdown.

```tsx
links: [
  { type: 'menu', text: 'Open app', items: [
    { text: 'Platform',    url: 'https://app.moleculesai.app',    external: true },
    { text: 'Marketplace', url: 'https://market.moleculesai.app', external: true },  // restored
    { text: 'Landing',     url: 'https://www.moleculesai.app',    external: true },
  ] },
],
```

Both Marketplace surfaces are now reachable: docs section via the **"Marketplace" tab** (from #134); SaaS app via the **dropdown** (this PR).

## Verification
- `tsc --noEmit` clean
- `pnpm build` clean
- All three docs-accuracy gates pass: stale-refs ✓, broken-link ✓, home-hrefs ✓
- 21 LOC change, 1 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
