### PR TITLE
fix(docs): execFileSync (argv) for git log — shellsafe per #136 self-review

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { source } from '@/lib/source';
 import {
   DocsBody,
@@ -28,10 +28,19 @@ function getLastUpdate(filePath: string): number | null {
     // null on any failure (build without .git, file outside the repo,
     // etc.) — we'd rather hide the "Last updated" line than crash the
     // page build.
-    const iso = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
+    //
+    // execFileSync (not execSync) — passes filePath as an argv element
+    // straight to git, never via /bin/sh. Defense-in-depth: page.path
+    // today comes from fumadocs and is safe, but a future content file
+    // with a space in the name (or worse) wouldn't break this call.
+    const iso = execFileSync(
+      'git',
+      ['log', '-1', '--format=%cI', '--', filePath],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    ).trim();
     if (iso) {
       const t = Date.parse(iso);
       if (!Number.isNaN(t)) result = t;


### PR DESCRIPTION
## Self-review finding (Important)

#136 (lastUpdate + editOnGithub) just shipped, but `getLastUpdate()` builds the shell command via string interpolation:

```ts
execSync(`git log -1 --format=%cI -- "${filePath}"`, ...)
```

`filePath` comes from fumadocs' `page.path` (under `content/docs/`), so practically safe today. But:

- A future content file with a space in the name (e.g. `content/docs/some new page.md`) would break the quoted command.
- A malicious commit-of-content with shell-meaningful chars in a filename would inject. (Low likelihood — we control content — but defense-in-depth is one-line.)

## Fix

Switch to `execFileSync('git', ['log', '-1', '--format=%cI', '--', filePath], opts)`. Args go directly into the child process's argv — no shell, no interpolation, no quoting concerns.

No behavior change for current valid filePaths. 14 LOC change, 1 file.

## Verification
- `tsc --noEmit` clean
- `pnpm build` clean
- All three docs-accuracy gates pass: stale-refs ✓, broken-link ✓, home-hrefs ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
