### PR TITLE
docs(plugins): drop misleading 'MCP server' shape row, document runtimes manifest field

### DIFF
--- a/content/docs/plugins.mdx
+++ b/content/docs/plugins.mdx
@@ -35,11 +35,17 @@ runtime.
 | Shape | Description |
 |-------|-------------|
 | agentskills.io format | `SKILL.md` + optional scripts, hooks, and `plugin.yaml` manifest |
-| MCP server | Model Context Protocol server (coming soon for more runtimes) |
 
-The shape is orthogonal to the source. A `github://` plugin and a `local://`
-plugin can both be agentskills.io format. The per-runtime adapter inside the
-workspace handles loading at startup.
+The shape is orthogonal to the source — a `github://` plugin and a
+`local://` plugin can both be agentskills.io format. The per-runtime
+adapter inside the workspace handles loading at startup.
+
+The `plugin.yaml` manifest declares which `runtimes` the plugin
+supports (claude-code, hermes, opencode, etc.), so an installer can
+refuse a plugin that isn't compatible with the workspace's runtime
+before it lands in `/configs/plugins/`. See
+[Runtime Compatibility Check](#runtime-compatibility-check) below
+for the runtime-side contract.
 
 ---
 


### PR DESCRIPTION
## Summary

The plugin shapes table claimed MCP-server plugins were "coming soon for more runtimes". Verified against the actual loader: there is no MCP-plugin shape — \`workspace/plugins.py\`'s PluginManifest only supports the agentskills.io format. Drop the misleading row, and add a short paragraph documenting the actual \`runtimes\` manifest field that's been there.

## Verification

- \`workspace/plugins.py:30-41\` PluginManifest has fields \`{name, version, description, author, tags, skills, rules, prompt_fragments, adapters, runtimes}\`. **No** mcp_servers / mcp_plugin / McpServer field anywhere.
- Greppd \`workspace-server/internal/handlers/plugins*.go\` for any MCP plugin shape — none.
- \`runtimes\` field semantics confirmed via inline comment: \`runtimes: list[str] = ...  # declared supported runtimes\`.
- Self-review caught my own broken anchor — initial draft linked to \`#adapter-integration\` which doesn't exist; corrected to the actual \`#runtime-compatibility-check\` section.

Docs gates:
- ✓ check-stale-refs.sh
- ✓ check-broken-links.py
- ✓ check-home-hrefs.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)